### PR TITLE
Fix from in send transaction

### DIFF
--- a/sample/with_be/front/index.html
+++ b/sample/with_be/front/index.html
@@ -14,6 +14,7 @@
       <p id="tx"></p>
       <button id="sign" disabled>sign</button>
       <p id="signature"></p>
+      <button id="reset">reset cache</button>
     </div>
 
     <script src="http://localhost:3005/main.js"></script>
@@ -56,8 +57,10 @@
         sendButton.removeAttribute('disabled')
 
         sendButton.addEventListener('click', () => {
-          web3.eth.sendTransaction({ from: provider.selectedAddress, to: provider.selectedAddress, value: '10000000' }, (err, tx) => {
-            document.getElementById('tx').innerHTML = tx
+          web3.eth.getAccounts().then(accounts => {
+            web3.eth.sendTransaction({ from: accounts[0], to: accounts[0], value: '10000000' }, (err, tx) => {
+              document.getElementById('tx').innerHTML = tx
+            })
           })
         });
 
@@ -70,6 +73,11 @@
           })
         });
       }
+
+      document.getElementById('reset').addEventListener('click', () => {
+        localStorage.removeItem('RLOGIN_AUTH_TOKEN_LOCAL_STORAGE_KEY')
+        localStorage.removeItem('walletconnect')
+      })
     </script>
   </body>
 </html>


### PR DESCRIPTION
- `provider` has the same issue discovered in #10. Lack of polymorphism :( this was easy fixed using get accounts avoiding `if type of provider is...`
- Adds reset button that deletes local storage. Now is faster to test 👍 

Related to #10, I added this PR into RSK Wallet Connect POC https://github.com/rsksmart/RSKWalletConnect/pull/1. That can be used to test _open_ flavor :)

If this changes are ok, this branch can be merged into `add-wallet-connect`. After this, we can merge `add-wallet-connect` into `master`