### PR TITLE
Use send instead of request to work with Nifty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "description": "rLogin - the web3.0 SDK",
   "main": "dist/main.js",
   "files": [

--- a/src/components/Core.tsx
+++ b/src/components/Core.tsx
@@ -73,8 +73,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
       this.setState({ provider })
 
       Promise.all([
-        provider.request({ method: 'eth_accounts' }),
-        provider.request({ method: 'net_version' })
+        provider.send({ method: 'eth_accounts' }),
+        provider.send({ method: 'net_version' })
       ]).then(([accounts, netVersion]) => {
         const chainId = parseInt(netVersion)
         this.setState({ chainId })

--- a/src/components/Core.tsx
+++ b/src/components/Core.tsx
@@ -76,7 +76,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         provider.send({ method: 'eth_accounts' }),
         provider.send({ method: 'net_version' })
       ]).then(([accounts, netVersion]) => {
-        const chainId = parseInt(netVersion)
+        const chainId = parseInt(netVersion.result || netVersion)
         this.setState({ chainId })
 
         if (!this.validateCurrentChain()) return


### PR DESCRIPTION
Rather than using `provider.send()` or `provider.request()`, get the address and chain Id directly from the provider.

**Notes**

- `provider.request()` is not supported by Nifty Wallet
- `provider.send()` returns a promise with Nifty and WalletConnect, but returns an object with Metamask. Although the docs say it should return a promise.

This is a quick fix to work with the rif-identity-manager, and does not address the issue with the demo (sample/front/index.html) that is broken in Nifty because it uses `provider.request` for methods.

**What changed?**

GIthub's analysis of the changes is larger than what it seems because of the removal of indents.

The promise was removed, and chainId and address are reterived this way:

```
const chainId = parseInt(provider.chainId)
const address = provider.selectedAddress || provider.accounts[0]
```

`provider.accounts[0]` is for WalletConnect

**Tested with rif-identity-manager**

Tested with metamask, nifty, and wallet connect.