### PR TITLE
Nifty wallet support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "description": "rLogin - the web3.0 SDK",
   "main": "dist/main.js",
   "files": [

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -85,14 +85,19 @@
       const displayDisconnectError = ({ message, code, data }) => setElementInnerHTML('error', `message: ${message} - code: ${code} - data: ${data}`)
       const displayAccessToken = (accessToken) => setElementInnerHTML('access-token', accessToken)
 
+      function providerRPC (provider, args) {
+        // ref: https://github.com/rsksmart/rLogin/pull/15#pullrequestreview-529574033
+        if (provider.isNiftyWallet) return provider.send(args.method, args.params)
+        return provider.request(args)
+      }
       // json rpc methods
-      const getAccounts = (provider) => provider.request({ method: 'eth_accounts' })
-      const getNetwork = (provider) => provider.request({ method: 'net_version' }).then(parseInt)
+      const getAccounts = (provider) => providerRPC(provider, { method: 'eth_accounts' })
+      const getNetwork = (provider) => providerRPC(provider, { method: 'net_version' }).then(parseInt)
       const getChainId = (provider) => getNetwork(provider).then(networkId => `0x${networkId.toString(16)}`) // keeping it consistent with eip-1193
-      const sendTransaction = (provider, params) => provider.request({ method: 'eth_sendTransaction', params })
-      const sign = (provider, params) => provider.request({ method: 'personal_sign', params })
-      const ecRecover = (provider, params) => provider.request({ method: 'personal_ecRecover', params })
-      const signTypedData = (provider, params) => provider.request({ method: 'eth_signTypedData_v4', params })
+      const sendTransaction = (provider, params) => providerRPC(provider, { method: 'eth_sendTransaction', params })
+      const sign = (provider, params) => providerRPC(provider, { method: 'personal_sign', params })
+      const ecRecover = (provider, params) => providerRPC(provider, { method: 'personal_ecRecover', params })
+      const signTypedData = (provider, params) => providerRPC(provider, { method: 'eth_signTypedData', params })
 
       function handleProvider(provider) {
         document.getElementById('connected').innerHTML = 'Yes'

--- a/src/components/Core.tsx
+++ b/src/components/Core.tsx
@@ -73,8 +73,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
       this.setState({ provider })
 
       Promise.all([
-        provider.request({ method: 'eth_accounts' }),
-        provider.request({ method: 'net_version' })
+        provider.send({ method: 'eth_accounts' }),
+        provider.send({ method: 'net_version' })
       ]).then(([accounts, netVersion]) => {
         const chainId = parseInt(netVersion)
         this.setState({ chainId })

--- a/src/components/Core.tsx
+++ b/src/components/Core.tsx
@@ -76,7 +76,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         provider.send({ method: 'eth_accounts' }),
         provider.send({ method: 'net_version' })
       ]).then(([accounts, netVersion]) => {
-        const chainId = parseInt(netVersion)
+        const chainId = parseInt(netVersion.result || netVersion)
         this.setState({ chainId })
 
         if (!this.validateCurrentChain()) return


### PR DESCRIPTION
This PR was opened after analysing different approaches to handle Nifty wallet support for rLogin. The problem is correctly described on this PR https://github.com/rsksmart/rLogin/pull/15

This new PR was tested with:
- Metamask Ethereum mainnet and RSK mainnet
- Nifty wallet Ethereum mainnet and RSK mainnet
- Trust wallet + Wallet connect with Ethereum mainnet

Changes:
- Implements `if nifty` to use `send` instead of `request` on rLogin core
- Implements `if nifty` in sample app too