### PR TITLE
Add margin to paragraph and header3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "0.0.1-beta.3",
+  "version": "0.0.1-beta.4",
   "description": "rLogin - the web3.0 SDK",
   "main": "dist/main.js",
   "files": [

--- a/src/components/shared/Typography.tsx
+++ b/src/components/shared/Typography.tsx
@@ -29,6 +29,7 @@ const Header3Wrapper = styled.h3`
   font-weight: 500 !important;
   font-size: 18px;
   color: #6C6B6C;
+  margin: 18px 0;
 `
 
 export const Header3: React.FC<TypographyInterface> = ({ children, className }) => (
@@ -42,6 +43,7 @@ const ParagraphWrapper = styled.p`
   font-weight: 400 !important;
   font-size: 12px;
   color: #B0AEB1;
+  margin: 12px 0;
 `
 export const Paragraph: React.FC<TypographyInterface> = ({ children, className }) => (
   <ParagraphWrapper className={className ? `${PARAGRAPH_CLASS} ${className}` : PARAGRAPH_CLASS}>


### PR DESCRIPTION
Add margin explicitly in if "host" CSS has `margin: 0` on p and h3. 

Fixes import issue in the RNS Manager. 