### PR TITLE
Allow user to only have WalletConnect for the sample apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1827,47 +1827,6 @@
         "buffer": "^6.0.3",
         "did-jwt": "^4.6.2",
         "eth-sig-util": "^3.0.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "did-jwt": {
-          "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.8.1.tgz",
-          "integrity": "sha512-TRfk6He4MSUe3mN+YBqX4wC8N4ns3jan0Ckwal6fPsexKYRwo20ns8w0IGt7J4oHOF3IxXNAkH07OBdEpMnEdA==",
-          "requires": {
-            "@babel/runtime": "^7.11.2",
-            "@stablelib/ed25519": "^1.0.1",
-            "@stablelib/random": "^1.0.0",
-            "@stablelib/sha256": "^1.0.0",
-            "@stablelib/x25519": "^1.0.0",
-            "@stablelib/xchacha20poly1305": "^1.0.0",
-            "did-resolver": "^2.1.2",
-            "elliptic": "^6.5.3",
-            "js-sha3": "^0.8.0",
-            "uint8arrays": "^2.0.0"
-          }
-        },
-        "ethereumjs-abi": {
-          "dependencies": {
-            "ethereumjs-util": {}
-          }
-        }
       }
     },
     "@sindresorhus/is": {
@@ -4873,9 +4832,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
     },
     "csurf": {
       "version": "1.11.0",
@@ -5217,7 +5176,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.8.1.tgz",
       "integrity": "sha512-TRfk6He4MSUe3mN+YBqX4wC8N4ns3jan0Ckwal6fPsexKYRwo20ns8w0IGt7J4oHOF3IxXNAkH07OBdEpMnEdA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@stablelib/ed25519": "^1.0.1",

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -42,7 +42,9 @@
     <script src="https://unpkg.com/@walletconnect/web3-provider@1.2.1/dist/umd/index.min.js"></script>
 
     <script type="text/javascript">
-      window.ethereum.autoRefreshOnNetworkChange = false
+      if (window.ethereum) {
+        window.ethereum.autoRefreshOnNetworkChange = false
+      }
 
       // detect flavor
       const withBackend = new URLSearchParams(window.location.search).get('backend') === 'yes'


### PR DESCRIPTION
Check if window.ethereum exists before setting the autorefresh setting in the sample app.

- Setting has to do with Metamask, in the case that window.ethereum is not loaded, the app should not break. I.e. when using only Wallet Connect
- package-lock.json changes were done by npm

Resolves #44