### PR TITLE
Handle long URLs without breaking design

### DIFF
--- a/src/ui/modal/ModalBody.tsx
+++ b/src/ui/modal/ModalBody.tsx
@@ -2,4 +2,5 @@ import styled from 'styled-components'
 
 export const ModalBody = styled.div`
   padding: 10px 24px;
+  max-width: 440px;
 `

--- a/src/ui/modal/ModalCard.tsx
+++ b/src/ui/modal/ModalCard.tsx
@@ -10,8 +10,6 @@ const ModalCardWrapper = styled.div`
   border-radius: 12px;
   margin: 10px;
   padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   max-width: 440px;
   min-width: fit-content;
   max-height: 100%;

--- a/src/ux/step2/SelectiveDisclosureRequest.tsx
+++ b/src/ux/step2/SelectiveDisclosureRequest.tsx
@@ -19,7 +19,7 @@ const RequestsList = ({ requests }: { requests: string[] }) => requests.length ?
 
 const SelectiveDisclosureRequest = ({ sdr: { credentials, claims }, backendUrl, onConfirm, isLoading }: SelectiveDisclosureRequestProps) => <>
   <Header2>Would you like to give us<br />access to info in your data vault?</Header2>
-  <Paragraph>Get the information you want to share with {backendUrl} from you Data Vault</Paragraph>
+  <Paragraph>Get the information you want to share with <span style={{ wordBreak: 'break-all' }}>{backendUrl}</span> from you Data Vault</Paragraph>
   <NarrowBox>
     <RequestsList requests={claims} />
     <RequestsList requests={credentials} />

--- a/src/ux/step2/SelectiveDisclosureResponse.tsx
+++ b/src/ux/step2/SelectiveDisclosureResponse.tsx
@@ -50,7 +50,7 @@ const SelectiveDisclosureResponse = ({ data: { credentials, claims }, backendUrl
 
   return <>
     <Header2>Select information to share</Header2>
-    <Paragraph>Sharing your information is optional. It will only be shared with {backendUrl}</Paragraph>
+    <Paragraph>Sharing your information is optional. It will only be shared with <span style={{ wordBreak: 'break-all' }}>{backendUrl}</span></Paragraph>
     <WideBox>
       <DataList dataField={claims} select={selectClaims} areCredentials={false} />
       <DataList dataField={credentials} select={selectCredentials} areCredentials={true} />


### PR DESCRIPTION
Added wordBreak to the URL< however that wasn't enough.

Updated `ModalCard` to remove column, and then for `ModalBody` added in a maxWidth that matches the cards.

You can test with the sample app in the repo, change the backend URL to the production one: `https://data-vault-sample-backend.rlogin.identity.rifos.org`

Resolves #66