### PR TITLE
Reset Wallet Connect

### DIFF
--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -78,7 +78,7 @@
 
       // setup login button
       document.getElementById('login').addEventListener('click', () => rLogin.connect().then(handleProvider));
-      document.getElementById('loginMetamask').addEventListener('click', () => rLogin.connectTo('injected').then(handleProvider));
+      document.getElementById('loginMetamask').addEventListener('click', () => rLogin.connectTo('injected').then(handleProvider).catch(err => console.log('Error: ', err)));
 
       // ui - display handlers
       const setElementInnerText = (elementId, content) => { document.getElementById(elementId).innerText = content }

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -267,11 +267,15 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
   public render = () => {
     const { show, lightboxOffset, currentStep, sd, sdr, chainId, address, errorReason } = this.state
-    const { onClose, userProviders, backendUrl } = this.props
+    const { onClose, userProviders, backendUrl, providerController } = this.props
     const did = this.did()
 
+    /**
+     * handleClose is fired when the modal or providerModal is closed by the user
+     */
     const handleClose = () => {
       this.setState({ currentStep: 'Step1' })
+      providerController.clearCachedProvider()
       onClose()
     }
 

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -16,7 +16,7 @@ import { ethAccounts, ethChainId } from './lib/provider'
 import { confirmAuth, requestSignup } from './lib/did-auth'
 import { createDataVault } from './lib/data-vault'
 import { fetchSelectiveDisclosureRequest } from './lib/sdr'
-import { RLOGIN_ACCESS_TOKEN, RLOGIN_REFRESH_TOKEN } from './constants'
+import { RLOGIN_ACCESS_TOKEN, RLOGIN_REFRESH_TOKEN, WALLETCONNECT } from './constants'
 
 // copy-pasted and adapted
 // https://github.com/Web3Modal/web3modal/blob/4b31a6bdf5a4f81bf20de38c45c67576c3249bfc/src/components/Modal.tsx
@@ -240,16 +240,25 @@ export class Core extends React.Component<IModalProps, IModalState> {
   }
 
   /**
+   * Disconnect from WalletConnect if it is the selected provider
+   * @param provider web3 Provider
+   */
+  private disconnectWC (provider: any): void {
+    if (provider.wc) {
+      provider.disconnect()
+      localStorage.removeItem(WALLETCONNECT)
+    }
+  }
+
+  /**
    * Handle disconnect and cleanup state
    */
   public disconnect (): void {
     const { providerController } = this.props
+    const { provider } = this.state
 
     // send disconnect method to wallet connect
-    if (this.state.provider.wc) {
-      this.state.provider.disconnect()
-      localStorage.removeItem('walletconnect')
-    }
+    this.disconnectWC(provider)
 
     localStorage.removeItem(RLOGIN_ACCESS_TOKEN)
     localStorage.removeItem(RLOGIN_REFRESH_TOKEN)
@@ -266,7 +275,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
   }
 
   public render = () => {
-    const { show, lightboxOffset, currentStep, sd, sdr, chainId, address, errorReason } = this.state
+    const { show, lightboxOffset, currentStep, sd, sdr, chainId, address, errorReason, provider } = this.state
     const { onClose, userProviders, backendUrl, providerController } = this.props
     const did = this.did()
 
@@ -275,6 +284,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
      */
     const handleClose = () => {
       this.setState({ currentStep: 'Step1' })
+      this.disconnectWC(provider)
       providerController.clearCachedProvider()
       onClose()
     }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
 export const RLOGIN_REFRESH_TOKEN = 'RLOGIN_REFRESH_TOKEN'
 export const RLOGIN_ACCESS_TOKEN = 'RLOGIN_ACCESS_TOKEN'
 export const DECRYPT_ERROR = 'DECRYPT_ERROR'
+
+export const WALLETCONNECT = 'walletconnect'


### PR DESCRIPTION
## Remove cachedProvider on user close

When the user closes the modal by clicking on the `X`, the background, or the WalletConnect `X`, clear the cachedProvider. This way, the user has the option to select a different connection method. In addition, check if the provider is WalletConnect and remove that local storage variable also.

This does not remove the DataVault authentication, which will only be removed on a disconnect.

## WalletConnect variable

WalletConnect adds an additional local storage variable called `walletconnect` that was only being cleared when the user clicked 'disconnect'. What was happening was WC would try to use this variable even if the cached LS variable was cleared. This could sometimes prompt a QR code and not allow a user to choose another method.

Resolves #75 
