### PR TITLE
Add or Switch to Network feature if on the wrong network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ rLogin is a tool that allows the front end developer to connect their user with 
     - RSK Testnet
     - Ethereum Mainnet
     - Ganache (test network)
+- Add or Switch to Network if the user is on a different network.
+  - Supports RSK networks, but open to PRs for additional chains
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "rLogin - the web3.0 SDK",
   "main": "dist/main.js",
   "files": [

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -87,9 +87,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
     const { providerController, onError } = props
 
-    providerController.on(CONNECT_EVENT, (provider: any) => {
-      this.setupProvider(provider).then((success) => { if (success) { return this.detectFlavor() } })
-    })
+    providerController.on(CONNECT_EVENT, (provider: any) => this.continueSettingUp(provider))
 
     providerController.on(ERROR_EVENT, (error: any) => onError(error))
 
@@ -97,6 +95,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     this.setLightboxRef = this.setLightboxRef.bind(this)
 
     this.changeMetamaskNetwork = this.changeMetamaskNetwork.bind(this)
+    this.continueSettingUp = this.continueSettingUp.bind(this)
     this.fetchSelectiveDisclosureRequest = this.fetchSelectiveDisclosureRequest.bind(this)
     this.onConfirmSelectiveDisclosure = this.onConfirmSelectiveDisclosure.bind(this)
     this.onConfirmAuth = this.onConfirmAuth.bind(this)
@@ -141,6 +140,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
     return this.validateCurrentChain()
   }
 
+  private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => { if (success) { return this.detectFlavor() } })
+
   private validateCurrentChain () {
     const { supportedChains } = this.props
     const { chainId, provider } = this.state
@@ -148,7 +149,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     const isCurrentChainSupported = supportedChains && supportedChains.includes(chainId!)
 
     if (!isCurrentChainSupported) {
-      provider.on(CHAIN_CHANGED, () => this.setState({ currentStep: 'Step1' }))
+      provider.on(CHAIN_CHANGED, () => this.continueSettingUp(provider))
 
       this.setState({ currentStep: 'wrongNetwork' })
     }
@@ -159,7 +160,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
   private changeMetamaskNetwork (params: AddEthereumChainParameter) {
     const { provider } = this.state
     addEthereumChain(provider, params)
-      .then(() => this.setState({ currentStep: 'Step1' }))
+      .then(() => this.continueSettingUp(provider))
       // user cancelled the addition or switch, don't do anything:
       .catch()
   }

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -13,11 +13,12 @@ import { ErrorMessage } from './ui/shared/ErrorMessage'
 
 import { ACCOUNTS_CHANGED, CHAIN_CHANGED, CONNECT_EVENT, ERROR_EVENT } from './constants/events'
 import { getDID, getChainId } from './adapters'
-import { addEthereumChain, AddEthereumChainParameter, ethAccounts, ethChainId, isMetamask } from './lib/provider'
+import { addEthereumChain, ethAccounts, ethChainId, isMetamask } from './lib/provider'
 import { confirmAuth, requestSignup } from './lib/did-auth'
 import { createDataVault } from './lib/data-vault'
 import { fetchSelectiveDisclosureRequest } from './lib/sdr'
 import { RLOGIN_ACCESS_TOKEN, RLOGIN_REFRESH_TOKEN, WALLETCONNECT } from './constants'
+import { AddEthereumChainParameter } from './ux/wrongNetwork/changeNetwork'
 
 // copy-pasted and adapted
 // https://github.com/Web3Modal/web3modal/blob/4b31a6bdf5a4f81bf20de38c45c67576c3249bfc/src/components/Modal.tsx

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -308,7 +308,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
       {currentStep === 'Step2' && <SelectiveDisclosure sdr={sdr!} backendUrl={backendUrl!} fetchSelectiveDisclosureRequest={this.fetchSelectiveDisclosureRequest} onConfirm={this.onConfirmSelectiveDisclosure} />}
       {currentStep === 'Step3' && <ConfirmSelectiveDisclosure did={(chainId && address) ? did : ''} sd={sd!} onConfirm={this.onConfirmAuth} />}
       {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description}/>}
-      {currentStep === 'wrongNetwork' && <WrongNetworkComponent currentNetwork={chainId} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
+      {currentStep === 'wrongNetwork' && <WrongNetworkComponent supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
     </Modal>
   }
 }

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -157,13 +157,11 @@ export class Core extends React.Component<IModalProps, IModalState> {
   }
 
   private changeMetamaskNetwork (params: AddEthereumChainParameter) {
-    console.log('params', params)
     const { provider } = this.state
     addEthereumChain(provider, params)
-      .then(() => {
-        this.setState({ currentStep: 'Step1' })
-      })
-      .catch((err: Error) => console.log('da error', err.message))
+      .then(() => this.setState({ currentStep: 'Step1' }))
+      // user cancelled the addition or switch, don't do anything:
+      .catch()
   }
 
   /** Step 1 confirmed - user picked a wallet provider */

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -13,8 +13,12 @@ export function getDID (chainId: number, address: string) {
 export function getChainName (chainId: number) {
   switch (chainId) {
     case 1: return 'Ethereum Mainnet'
+    case 3: return 'Ropsten Testnet'
+    case 4: return 'Rinkeby Testnet'
     case 30: return 'RSK Mainnet'
     case 31: return 'RSK Testnet'
+    case 42: return 'Kovan Testnet'
+    case 420: return 'Goerli Testnet'
     default: return `Network Id ${chainId}`
   }
 }

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -12,9 +12,10 @@ export function getDID (chainId: number, address: string) {
 
 export function getChainName (chainId: number) {
   switch (chainId) {
-    case 30: return 'RSK'
+    case 1: return 'Ethereum Mainnet'
+    case 30: return 'RSK Mainnet'
     case 31: return 'RSK Testnet'
-    default: return `network Id ${chainId}`
+    default: return `Network Id ${chainId}`
   }
 }
 

--- a/src/lib/data-vault.ts
+++ b/src/lib/data-vault.ts
@@ -1,4 +1,4 @@
-import { EIP1193Provider } from './provider'
+import { EIP1193Provider, isMetamask } from './provider'
 import DataVaultWebClient, { AuthManager, AsymmetricEncryptionManager, SignerEncryptionManager } from '@rsksmart/ipfs-cpinner-client'
 
 export const createDataVault = async (provider: EIP1193Provider, did: string, address: string) => {
@@ -8,7 +8,7 @@ export const createDataVault = async (provider: EIP1193Provider, did: string, ad
   return new DataVaultWebClient({
     serviceUrl,
     authManager: new AuthManager({ did, serviceUrl, personalSign }),
-    encryptionManager: provider.isMetaMask && !provider.isNiftyWallet
+    encryptionManager: isMetamask(provider)
       ? await AsymmetricEncryptionManager.fromWeb3Provider(provider)
       : await SignerEncryptionManager.fromWeb3Provider(provider)
   })

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -12,13 +12,13 @@ export interface EIP1193Provider {
 
 export interface AddEthereumChainParameter {
   chainId: string;
-  chainName?: string;
-  nativeCurrency?: {
-    name?: string;
-    symbol?: string;
-    decimals?: 18;
+  chainName: string;
+  nativeCurrency: {
+    name: string;
+    symbol: string;
+    decimals: 18;
   };
-  rpcUrls?: string[];
+  rpcUrls: string[];
   blockExplorerUrls?: string[];
   iconUrls?: string[]; // Currently ignored.
 }

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,3 +1,5 @@
+import { AddEthereumChainParameter } from '../ux/wrongNetwork/changeNetwork'
+
 // https://eips.ethereum.org/EIPS/eip-1193
 interface RequestArguments {
   readonly method: string;
@@ -8,19 +10,6 @@ export interface EIP1193Provider {
   request<T = string>(args: RequestArguments): Promise<T>
   isMetaMask: boolean | null
   isNiftyWallet: boolean | null
-}
-
-export interface AddEthereumChainParameter {
-  chainId: string;
-  chainName: string;
-  nativeCurrency: {
-    name: string;
-    symbol: string;
-    decimals: 18;
-  };
-  rpcUrls: string[];
-  blockExplorerUrls?: string[];
-  iconUrls?: string[]; // Currently ignored.
 }
 
 export const ethAccounts = (provider: EIP1193Provider) => provider.request<string[]>({ method: 'eth_accounts' })

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -10,6 +10,22 @@ export interface EIP1193Provider {
   isNiftyWallet: boolean | null
 }
 
+export interface AddEthereumChainParameter {
+  chainId: string;
+  chainName?: string;
+  nativeCurrency?: {
+    name?: string;
+    symbol?: string;
+    decimals?: 18;
+  };
+  rpcUrls?: string[];
+  blockExplorerUrls?: string[];
+  iconUrls?: string[]; // Currently ignored.
+}
+
 export const ethAccounts = (provider: EIP1193Provider) => provider.request<string[]>({ method: 'eth_accounts' })
 export const ethChainId = (provider: EIP1193Provider) => provider.request<string>({ method: 'eth_chainId' })
 export const personalSign = (provider: EIP1193Provider, address: string, data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
+export const addEthereumChain = (provider: EIP1193Provider, params: AddEthereumChainParameter) => provider.request({ method: 'wallet_addEthereumChain', params: [params] })
+
+export const isMetamask = (provider: EIP1193Provider) => provider.isMetaMask && !provider.isNiftyWallet

--- a/src/ux/wrongNetwork/ChangeNetworkButton.test.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.test.tsx
@@ -1,0 +1,34 @@
+// eslint-disable-next-line no-use-before-define
+import React from 'react'
+import { mount } from 'enzyme'
+import ChangeNetworkButton from './ChangeNetworkButton'
+import { networks } from './changeNetwork'
+
+describe('Component: ChangeNetworkButton', () => {
+  const params = networks.get(30)
+  const sharedProps = {
+    changeNetwork: jest.fn(),
+    params
+  }
+
+  it('renders the component', () => {
+    const wrapper = mount(<ChangeNetworkButton {...sharedProps} />)
+    expect(wrapper).toBeDefined()
+    expect(wrapper.text()).toBe('RSK Mainnet')
+  })
+
+  it('displays an image when passed', () => {
+    const wrapper = mount(<ChangeNetworkButton {...sharedProps} />)
+    expect(wrapper.find('span')).toHaveLength(1)
+  })
+
+  it('handles changeNetwork click', () => {
+    const changeNetwork = jest.fn()
+    const localProps = { ...sharedProps, changeNetwork }
+    const wrapper = mount(<ChangeNetworkButton {...localProps} />)
+    wrapper.find('button').simulate('click')
+
+    expect(changeNetwork).toBeCalledTimes(1)
+    expect(changeNetwork).toBeCalledWith(params)
+  })
+})

--- a/src/ux/wrongNetwork/ChangeNetworkButton.test.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.test.tsx
@@ -15,6 +15,7 @@ describe('Component: ChangeNetworkButton', () => {
     const wrapper = mount(<ChangeNetworkButton {...sharedProps} />)
     expect(wrapper).toBeDefined()
     expect(wrapper.text()).toBe('RSK Mainnet')
+    expect(wrapper.find('button.changeNetwork').hasClass('chain30')).toBeTruthy()
   })
 
   it('displays an image when passed', () => {

--- a/src/ux/wrongNetwork/ChangeNetworkButton.test.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.test.tsx
@@ -19,7 +19,7 @@ describe('Component: ChangeNetworkButton', () => {
 
   it('displays an image when passed', () => {
     const wrapper = mount(<ChangeNetworkButton {...sharedProps} />)
-    expect(wrapper.find('span')).toHaveLength(1)
+    expect(wrapper.find('span')).toHaveLength(2)
   })
 
   it('handles changeNetwork click', () => {

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -1,11 +1,11 @@
 // eslint-disable-next-line
 import React from 'react'
 import styled from 'styled-components'
-import { AddEthereumChainParameter } from '../../lib/provider'
+import { AddEthereumChainParameter } from './changeNetwork'
 
 interface ChangeNetworkButtonInterface {
   params: AddEthereumChainParameter | undefined,
-  changeNetwork: any
+  changeNetwork: (params: AddEthereumChainParameter) => void
 }
 
 const NetworkButton = styled.button`
@@ -38,19 +38,14 @@ const IconBox = styled.span`
   vertical-align: middle;
 `
 
-const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) => {
-  if (!params) return <></>
-
-  const handleChangeNetwork = () => changeNetwork(params)
-
-  return params ? (
+const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) =>
+  params ? (
     <NetworkButton
       className={`changeNetwork chain${parseInt(params.chainId)}`}
-      onClick={handleChangeNetwork}>
+      onClick={() => changeNetwork(params)}>
       {params.iconUrls && params.iconUrls[0] && <IconBox className="icon" url={params.iconUrls[0]} />}
       {params.chainName}
     </NetworkButton>
   ) : <></>
-}
 
 export default ChangeNetworkButton

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -27,15 +27,25 @@ const NetworkButton = styled.button`
   :focus {
     outline:0;
   }
+
+  .text {
+    display: inline-block;
+    margin-top: 2px;
+  }
 `
+type IconBoxType = {
+  url: string,
+  isTestnet: boolean
+}
 
 const IconBox = styled.span`
   display: inline-block;
   width: 45px;
   height: 45px;
-  background-image: url(${(props: { url: string; }) => props.url});
+  background-image: url(${(props: IconBoxType) => props.url});
   background-size: cover;
   vertical-align: middle;
+  ${(props: IconBoxType) => props.isTestnet && 'filter: grayscale(100%);'}
 `
 
 const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) =>
@@ -43,8 +53,8 @@ const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, c
     <NetworkButton
       className={`changeNetwork chain${parseInt(params.chainId)}`}
       onClick={() => changeNetwork(params)}>
-      {params.iconUrls && params.iconUrls[0] && <IconBox className="icon" url={params.iconUrls[0]} />}
-      {params.chainName}
+      {params.iconUrls && params.iconUrls[0] && <IconBox className="icon" url={params.iconUrls[0]} isTestnet={params.chainName.toLowerCase().endsWith('testnet')} />}
+      <span className="text">{params.chainName}</span>
     </NetworkButton>
   ) : <></>
 

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -46,7 +46,7 @@ const IconBox = styled.span`
 
 const ChainName = styled.span`
   display: inline-block;
-  ${(props: { isTestnet: boolean }) => props.isTestnet && 'color: #AAAAAA;' }
+  ${(props: { isTestnet: boolean }) => props.isTestnet && 'color: #AAAAAA;'}
 `
 
 const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) =>

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -27,11 +27,6 @@ const NetworkButton = styled.button`
   :focus {
     outline:0;
   }
-
-  .text {
-    display: inline-block;
-    margin-top: 2px;
-  }
 `
 type IconBoxType = {
   url: string,
@@ -46,6 +41,12 @@ const IconBox = styled.span`
   background-size: cover;
   vertical-align: middle;
   ${(props: IconBoxType) => props.isTestnet && 'filter: grayscale(100%);'}
+  margin-top: -2px;
+`
+
+const ChainName = styled.span`
+  display: inline-block;
+  font-weight: ${(props: { isTestnet: boolean }) => props.isTestnet ? '400' : '600' } !important;
 `
 
 const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) =>
@@ -54,7 +55,7 @@ const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, c
       className={`changeNetwork chain${parseInt(params.chainId)}`}
       onClick={() => changeNetwork(params)}>
       {params.iconUrls && params.iconUrls[0] && <IconBox className="icon" url={params.iconUrls[0]} isTestnet={params.chainName.toLowerCase().endsWith('testnet')} />}
-      <span className="text">{params.chainName}</span>
+      <ChainName isTestnet={params.chainName.toLowerCase().endsWith('testnet')}>{params.chainName}</ChainName>
     </NetworkButton>
   ) : <></>
 

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -16,7 +16,9 @@ const NetworkButton = styled.button`
   background-color: #F2F2F2;
   border-radius: 12px;
   padding: 12px;
-  font-size: 18px;
+  font-size: 15px;
+  color: #6C6B6C;
+  font-weight: 500 !important;
 
   :hover {
     background-color: #E4E4E4;
@@ -29,8 +31,8 @@ const NetworkButton = styled.button`
 
 const IconBox = styled.span`
   display: inline-block;
-  width: 50px;
-  height: 50px;
+  width: 45px;
+  height: 45px;
   background-image: url(${(props: { url: string; }) => props.url});
   background-size: cover;
   vertical-align: middle;

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -46,7 +46,7 @@ const IconBox = styled.span`
 
 const ChainName = styled.span`
   display: inline-block;
-  font-weight: ${(props: { isTestnet: boolean }) => props.isTestnet ? '400' : '600' } !important;
+  ${(props: { isTestnet: boolean }) => props.isTestnet && 'color: #AAAAAA;' }
 `
 
 const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) =>

--- a/src/ux/wrongNetwork/ChangeNetworkButton.tsx
+++ b/src/ux/wrongNetwork/ChangeNetworkButton.tsx
@@ -1,0 +1,54 @@
+// eslint-disable-next-line
+import React from 'react'
+import styled from 'styled-components'
+import { AddEthereumChainParameter } from '../../lib/provider'
+
+interface ChangeNetworkButtonInterface {
+  params: AddEthereumChainParameter | undefined,
+  changeNetwork: any
+}
+
+const NetworkButton = styled.button`
+  display: block;
+  width: 100%;
+  cursor: pointer;
+  border: none;
+  background-color: #F2F2F2;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 18px;
+
+  :hover {
+    background-color: #E4E4E4;
+  }
+
+  :focus {
+    outline:0;
+  }
+`
+
+const IconBox = styled.span`
+  display: inline-block;
+  width: 50px;
+  height: 50px;
+  background-image: url(${(props: { url: string; }) => props.url});
+  background-size: cover;
+  vertical-align: middle;
+`
+
+const ChangeNetworkButton: React.FC<ChangeNetworkButtonInterface> = ({ params, changeNetwork }) => {
+  if (!params) return <></>
+
+  const handleChangeNetwork = () => changeNetwork(params)
+
+  return params ? (
+    <NetworkButton
+      className={`changeNetwork chain${parseInt(params.chainId)}`}
+      onClick={handleChangeNetwork}>
+      {params.iconUrls && params.iconUrls[0] && <IconBox className="icon" url={params.iconUrls[0]} />}
+      {params.chainName}
+    </NetworkButton>
+  ) : <></>
+}
+
+export default ChangeNetworkButton

--- a/src/ux/wrongNetwork/NetworkUnorderedList.ts
+++ b/src/ux/wrongNetwork/NetworkUnorderedList.ts
@@ -8,25 +8,7 @@ export default styled.ul`
     padding: 5px 0;
     font-size: 13px;
 
-    button {
-      display: block;
-      width: 100%;
-      cursor: pointer;
-      border: none;
-      background-color: #F2F2F2;
-      border-radius: 12px;
-      padding: 12px;
-    }
-
-    button:hover {
-      background-color: #E4E4E4;
-    }
-
-    button:focus {
-      outline:0;
-    }
-
-    span {
+    span.text {
       display: block;
       padding: 5px;
     }

--- a/src/ux/wrongNetwork/NetworkUnorderedList.ts
+++ b/src/ux/wrongNetwork/NetworkUnorderedList.ts
@@ -11,6 +11,9 @@ export default styled.ul`
     span.text {
       display: block;
       padding: 5px;
+      font-size: 15px;
+      color: #6C6B6C;
+      font-weight: 400 !important;
     }
   }
 `

--- a/src/ux/wrongNetwork/NetworkUnorderedList.ts
+++ b/src/ux/wrongNetwork/NetworkUnorderedList.ts
@@ -7,9 +7,9 @@ export default styled.ul`
   li {
     padding: 5px 0;
     font-size: 13px;
+    display: block;
 
     span.text {
-      display: block;
       padding: 5px;
       font-size: 15px;
       color: #6C6B6C;

--- a/src/ux/wrongNetwork/NetworkUnorderedList.ts
+++ b/src/ux/wrongNetwork/NetworkUnorderedList.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components'
+
+export default styled.ul`
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  li {
+    padding: 5px 0;
+    font-size: 13px;
+
+    button {
+      display: block;
+      width: 100%;
+      cursor: pointer;
+      border: none;
+      background-color: #F2F2F2;
+      border-radius: 12px;
+      padding: 12px;
+    }
+
+    button:hover {
+      background-color: #E4E4E4;
+    }
+
+    button:focus {
+      outline:0;
+    }
+
+    span {
+      display: block;
+      padding: 5px;
+    }
+  }
+`

--- a/src/ux/wrongNetwork/OtherNetworkSpan.ts
+++ b/src/ux/wrongNetwork/OtherNetworkSpan.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+
+export default styled.span`
+    font-size: 12px;
+    color: #B0AEB1;
+`

--- a/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
@@ -5,6 +5,7 @@ import WrongNetworkComponent from './WrongNetworkComponent'
 import { networks } from './changeNetwork'
 
 describe('Component: WrongNetworkComponent', () => {
+  const metamaskParagraph = 'You are connected to an incorrect network on Metamask. '
   const sharedProps = {
     supportedNetworks: [1],
     isMetamask: true,
@@ -17,19 +18,19 @@ describe('Component: WrongNetworkComponent', () => {
   })
 
   describe('text', () => {
-    it('shows error message about incorrect network', () => {
+    it('shows error message too select network', () => {
       const wrapper = mount(<WrongNetworkComponent {...sharedProps} />)
-      expect(wrapper.find('h2').text()).toBe('Incorrect Network')
+      expect(wrapper.find('h2').text()).toBe('Select Network')
     })
 
     it('shows singular text', () => {
       const wrapper = mount(<WrongNetworkComponent {...sharedProps} />)
-      expect(wrapper.find('p').text()).toBe('Please change your wallet to the following network:')
+      expect(wrapper.find('p').text()).toBe(metamaskParagraph + 'Please change your wallet to the following network:')
     })
 
     it('shows plural text', () => {
       const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[1, 30, 31]} />)
-      expect(wrapper.find('p').text()).toBe('Please change your wallet to one of the following networks:')
+      expect(wrapper.find('p').text()).toBe(metamaskParagraph + 'Please change your wallet to one of the following networks:')
     })
 
     it('displays network names or chainIds', () => {
@@ -44,8 +45,8 @@ describe('Component: WrongNetworkComponent', () => {
     it('displays text when it can not change network', () => {
       const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[1, 30, 31]} />)
 
-      expect(wrapper.find('li').at(0).text()).toBe('Ethereum Mainnet')
-      expect(wrapper.find('button').at(0).text()).toBe('RSK Mainnet')
+      expect(wrapper.find('ul.automatic li').at(0).text()).toBe('RSK Mainnet')
+      expect(wrapper.find('ul.manual li').at(0).text()).toBe('Ethereum Mainnet')
     })
 
     it('sends the params when clicked', () => {

--- a/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
@@ -1,0 +1,67 @@
+// eslint-disable-next-line no-use-before-define
+import React from 'react'
+import { mount } from 'enzyme'
+import WrongNetworkComponent from './WrongNetworkComponent'
+import { networks } from './changeNetwork'
+
+describe('Component: WrongNetworkComponent', () => {
+  const sharedProps = {
+    currentNetwork: 31,
+    supportedNetworks: [1],
+    isMetamask: true,
+    changeNetwork: jest.fn()
+  }
+
+  it('renders the component', () => {
+    const wrapper = mount(<WrongNetworkComponent {...sharedProps} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  describe('text', () => {
+    it('shows error message about incorrect network', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} />)
+      expect(wrapper.find('h2').text()).toBe('Incorrect Network')
+    })
+
+    it('shows singular text', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} />)
+      expect(wrapper.find('p').text()).toBe('Please change your wallet to the following network:')
+    })
+
+    it('shows plural text', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[1, 30, 31]} />)
+      expect(wrapper.find('p').text()).toBe('Please change your wallet to one of the following networks:')
+    })
+
+    it('displays network names or chainIds', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[31, 498]} />)
+
+      expect(wrapper.find('li').at(0).text()).toBe('RSK Testnet')
+      expect(wrapper.find('li').at(1).text()).toBe('Network Id 498')
+    })
+  })
+
+  describe('can change network', () => {
+    it('displays text when it can not change network', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[1, 30, 31]} />)
+
+      expect(wrapper.find('li').at(0).text()).toBe('Ethereum Mainnet')
+      expect(wrapper.find('button').at(0).text()).toBe('RSK Mainnet')
+    })
+
+    it('sends the params when clicked', () => {
+      const changeNetwork = jest.fn()
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[31]} changeNetwork={changeNetwork} />)
+
+      wrapper.find('button').simulate('click')
+      expect(changeNetwork).toBeCalledWith(networks.get(31))
+    })
+  })
+
+  describe('non-metamask', () => {
+    it('shows text instead of buttons if !isMetamask', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} isMetamask={false} />)
+      expect(wrapper.find('button')).toHaveLength(0)
+    })
+  })
+})

--- a/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
@@ -60,7 +60,7 @@ describe('Component: WrongNetworkComponent', () => {
 
   describe('non-metamask', () => {
     it('shows text instead of buttons if !isMetamask', () => {
-      const wrapper = mount(<WrongNetworkComponent {...sharedProps} isMetamask={false} />)
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[30]} isMetamask={false} />)
       expect(wrapper.find('button')).toHaveLength(0)
     })
   })

--- a/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
@@ -5,7 +5,8 @@ import WrongNetworkComponent from './WrongNetworkComponent'
 import { networks } from './changeNetwork'
 
 describe('Component: WrongNetworkComponent', () => {
-  const metamaskParagraph = 'You are connected to an incorrect network on Metamask. '
+  const metamaskParagraph = 'You are connected to an incorrect network with Metamask. '
+  const singleText = 'Please change your wallet to the following network:'
   const sharedProps = {
     supportedNetworks: [1],
     isMetamask: true,
@@ -25,12 +26,17 @@ describe('Component: WrongNetworkComponent', () => {
 
     it('shows singular text', () => {
       const wrapper = mount(<WrongNetworkComponent {...sharedProps} />)
-      expect(wrapper.find('p').text()).toBe(metamaskParagraph + 'Please change your wallet to the following network:')
+      expect(wrapper.find('p').text()).toBe(metamaskParagraph + singleText)
     })
 
     it('shows plural text', () => {
       const wrapper = mount(<WrongNetworkComponent {...sharedProps} supportedNetworks={[1, 30, 31]} />)
       expect(wrapper.find('p').text()).toBe(metamaskParagraph + 'Please change your wallet to one of the following networks:')
+    })
+
+    it('shows generic wallet message when not with metamask', () => {
+      const wrapper = mount(<WrongNetworkComponent {...sharedProps} isMetamask={false} />)
+      expect(wrapper.find('p').text()).toBe('You are connected to an incorrect network with your wallet. ' + singleText)
     })
 
     it('displays network names or chainIds', () => {

--- a/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.test.tsx
@@ -6,7 +6,6 @@ import { networks } from './changeNetwork'
 
 describe('Component: WrongNetworkComponent', () => {
   const sharedProps = {
-    currentNetwork: 31,
     supportedNetworks: [1],
     isMetamask: true,
     changeNetwork: jest.fn()

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -59,7 +59,7 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
       {manualConnect.length !== 0 && (
         <>
           <Header3>
-            Available networks to be selected from 
+            Available networks to be selected from
             {isMetamask ? ' Metamask' : ' your wallet'}
           </Header3>
           <NetworkUnorderedList className="manual">

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -5,6 +5,7 @@ import { AddEthereumChainParameter, networks } from './changeNetwork'
 import { Paragraph, Header2, Header3 } from '../../ui/shared/Typography'
 import NetworkUnorderedList from './NetworkUnorderedList'
 import ChangeNetworkButton from './ChangeNetworkButton'
+import OtherNetworkSpan from './OtherNetworkSpan'
 
 interface WrongNetworkComponentInterface {
   supportedNetworks: number[] | undefined,
@@ -37,7 +38,7 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
     <div>
       <Header2>Select Network</Header2>
       <Paragraph>
-        {`You are connected to an incorrect network on ${isMetamask ? 'Metamask' : 'your wallet'}. `}
+        {`You are connected to an incorrect network with ${isMetamask ? 'Metamask' : 'your wallet'}. `}
         {'Please change your wallet to '}
         {supportedNetworks.length === 1
           ? <>the following network:</>
@@ -57,10 +58,13 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
 
       {manualConnect.length !== 0 && (
         <>
-          <Header3>Manually connect your wallet to</Header3>
+          <Header3>
+            Other available networks to be selected from 
+            {isMetamask ? ' Metamask' : ' your wallet'}
+          </Header3>
           <NetworkUnorderedList className="manual">
             {manualConnect.map((chainId: number) => (
-              <li key={chainId}><span className="text">{getChainName(chainId)}</span></li>))}
+              <li key={chainId}><OtherNetworkSpan>{getChainName(chainId)}</OtherNetworkSpan></li>))}
           </NetworkUnorderedList>
         </>
       )}

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -1,10 +1,9 @@
 // eslint-disable-next-line
 import React from 'react'
 import { getChainName } from '../../adapters'
-import { networks } from './changeNetwork'
+import { AddEthereumChainParameter, networks } from './changeNetwork'
 import { Paragraph, Header2 } from '../../ui/shared/Typography'
 import NetworkUnorderedList from './NetworkUnorderedList'
-import { AddEthereumChainParameter } from '../../lib/provider'
 import ChangeNetworkButton from './ChangeNetworkButton'
 
 interface WrongNetworkComponentInterface {

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -19,6 +19,9 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
     return <></>
   }
 
+  const handleChangeNetwork = (params: AddEthereumChainParameter | undefined) =>
+    params !== undefined && changeNetwork(params)
+
   return (
     <div>
       <Header2>Incorrect Network</Header2>
@@ -34,7 +37,7 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
         {supportedNetworks.map((chainId: number) =>
           <li key={chainId}>
             {networks.get(chainId) && isMetamask
-              ? <button className="changeNetwork" onClick={() => changeNetwork(networks.get(chainId))}>{getChainName(chainId)}</button>
+              ? <button className="changeNetwork" onClick={() => handleChangeNetwork(networks.get(chainId))}>{getChainName(chainId)}</button>
               : <span>{getChainName(chainId)}</span>
             }
           </li>

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -59,7 +59,7 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
       {manualConnect.length !== 0 && (
         <>
           <Header3>
-            Other available networks to be selected from 
+            Available networks to be selected from 
             {isMetamask ? ' Metamask' : ' your wallet'}
           </Header3>
           <NetworkUnorderedList className="manual">

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -4,11 +4,12 @@ import { getChainName } from '../../adapters'
 import { networks } from './changeNetwork'
 import { Paragraph, Header2 } from '../../ui/shared/Typography'
 import NetworkUnorderedList from './NetworkUnorderedList'
+import { AddEthereumChainParameter } from '../../lib/provider'
 
 interface WrongNetworkComponentInterface {
   supportedNetworks: number[] | undefined,
   isMetamask: boolean | null,
-  changeNetwork: (params: any) => void
+  changeNetwork: (params: AddEthereumChainParameter) => void
 }
 
 const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -35,8 +35,9 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
 
   return (
     <div>
-      <Header2>Incorrect Network</Header2>
+      <Header2>Select Network</Header2>
       <Paragraph>
+        {`You are connected to an incorrect network on ${isMetamask ? 'Metamask' : 'your wallet'}. `}
         {'Please change your wallet to '}
         {supportedNetworks.length === 1
           ? <>the following network:</>
@@ -47,7 +48,7 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
       {quickConnect.length !== 0 && (
         <>
           <Header3>Automatically connect Metamask to</Header3>
-          <NetworkUnorderedList className="manual">
+          <NetworkUnorderedList className="automatic">
             {quickConnect.map((chainId: number) => (
               <li key={chainId}><ChangeNetworkButton params={networks.get(chainId)} changeNetwork={handleChangeNetwork} /></li>))}
           </NetworkUnorderedList>

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -1,43 +1,15 @@
 // eslint-disable-next-line
 import React from 'react'
-import styled from 'styled-components'
 import { getChainName } from '../../adapters'
 import { networks } from './changeNetwork'
 import { Paragraph, Header2 } from '../../ui/shared/Typography'
+import NetworkUnorderedList from './NetworkUnorderedList'
 
 interface WrongNetworkComponentInterface {
   supportedNetworks: number[] | undefined,
   isMetamask: boolean | null,
   changeNetwork: (params: any) => void
 }
-
-const NetworkUnorderedList = styled.ul`
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  li {
-    padding: 5px 0;
-    font-size: 13px;
-
-    button {
-      display: block;
-      width: 100%;
-      cursor: pointer;
-      border: none;
-      background-color: #F2F2F2;
-      border-radius: 12px;
-      padding: 15px;
-    }
-
-    button:hover {
-      background-color: #E4E4E4;
-    }
-
-    button:focus {
-      outline:0;
-    }
-  }
-`
 
 const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
   supportedNetworks, isMetamask, changeNetwork
@@ -62,7 +34,7 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
           <li key={chainId}>
             {networks.get(chainId) && isMetamask
               ? <button className="changeNetwork" onClick={() => changeNetwork(networks.get(chainId))}>{getChainName(chainId)}</button>
-              : getChainName(chainId)
+              : <span>{getChainName(chainId)}</span>
             }
           </li>
         )}

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { getChainName } from '../../adapters'
 import { AddEthereumChainParameter, networks } from './changeNetwork'
-import { Paragraph, Header2 } from '../../ui/shared/Typography'
+import { Paragraph, Header2, Header3 } from '../../ui/shared/Typography'
 import NetworkUnorderedList from './NetworkUnorderedList'
 import ChangeNetworkButton from './ChangeNetworkButton'
 
@@ -22,6 +22,17 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
   const handleChangeNetwork = (params: AddEthereumChainParameter | undefined) =>
     params !== undefined && changeNetwork(params)
 
+  const quickConnect: number[] = []
+  let manualConnect: number[] = []
+
+  if (!isMetamask) {
+    manualConnect = supportedNetworks
+  } else {
+    supportedNetworks.map((chainId: number) => {
+      networks.get(chainId) ? quickConnect.push(chainId) : manualConnect.push(chainId)
+    })
+  }
+
   return (
     <div>
       <Header2>Incorrect Network</Header2>
@@ -33,16 +44,25 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
         }
       </Paragraph>
 
-      <NetworkUnorderedList>
-        {supportedNetworks.map((chainId: number) =>
-          <li key={chainId}>
-            {networks.get(chainId) && isMetamask
-              ? <ChangeNetworkButton params={networks.get(chainId)} changeNetwork={handleChangeNetwork} />
-              : <span className="text">{getChainName(chainId)}</span>
-            }
-          </li>
-        )}
-      </NetworkUnorderedList>
+      {quickConnect.length !== 0 && (
+        <>
+          <Header3>Automatically connect Metamask to</Header3>
+          <NetworkUnorderedList className="manual">
+            {quickConnect.map((chainId: number) => (
+              <li key={chainId}><ChangeNetworkButton params={networks.get(chainId)} changeNetwork={handleChangeNetwork} /></li>))}
+          </NetworkUnorderedList>
+        </>
+      )}
+
+      {manualConnect.length !== 0 && (
+        <>
+          <Header3>Manually connect your wallet to</Header3>
+          <NetworkUnorderedList className="manual">
+            {manualConnect.map((chainId: number) => (
+              <li key={chainId}><span className="text">{getChainName(chainId)}</span></li>))}
+          </NetworkUnorderedList>
+        </>
+      )}
     </div>
   )
 }

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -5,6 +5,7 @@ import { networks } from './changeNetwork'
 import { Paragraph, Header2 } from '../../ui/shared/Typography'
 import NetworkUnorderedList from './NetworkUnorderedList'
 import { AddEthereumChainParameter } from '../../lib/provider'
+import ChangeNetworkButton from './ChangeNetworkButton'
 
 interface WrongNetworkComponentInterface {
   supportedNetworks: number[] | undefined,
@@ -37,8 +38,8 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
         {supportedNetworks.map((chainId: number) =>
           <li key={chainId}>
             {networks.get(chainId) && isMetamask
-              ? <button className="changeNetwork" onClick={() => handleChangeNetwork(networks.get(chainId))}>{getChainName(chainId)}</button>
-              : <span>{getChainName(chainId)}</span>
+              ? <ChangeNetworkButton params={networks.get(chainId)} changeNetwork={handleChangeNetwork} />
+              : <span className="text">{getChainName(chainId)}</span>
             }
           </li>
         )}

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line
 import React from 'react'
+import styled from 'styled-components'
 import { getChainName } from '../../adapters'
 import { networks } from './changeNetwork'
 import { Paragraph, Header2 } from '../../ui/shared/Typography'
@@ -11,7 +12,37 @@ interface WrongNetworkComponentInterface {
   changeNetwork: (params: any) => void
 }
 
-const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({ supportedNetworks, changeNetwork }) => {
+const NetworkUnorderedList = styled.ul`
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  li {
+    padding: 5px 0;
+    font-size: 13px;
+
+    button {
+      display: block;
+      width: 100%;
+      cursor: pointer;
+      border: none;
+      background-color: #F2F2F2;
+      border-radius: 12px;
+      padding: 15px;
+    }
+
+    button:hover {
+      background-color: #E4E4E4;
+    }
+
+    button:focus {
+      outline:0;
+    }
+  }
+`
+
+const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
+  currentNetwork, supportedNetworks, isMetamask, changeNetwork
+}) => {
   if (!supportedNetworks) {
     return <></>
   }
@@ -27,16 +58,16 @@ const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({ suppo
         }
       </Paragraph>
 
-      <ul>
+      <NetworkUnorderedList>
         {supportedNetworks.map((chainId: number) =>
           <li key={chainId}>
-            {networks.get(chainId)
+            {networks.get(chainId) && isMetamask
               ? <button className="changeNetwork" onClick={() => changeNetwork(networks.get(chainId))}>{getChainName(chainId)}</button>
               : getChainName(chainId)
             }
           </li>
         )}
-      </ul>
+      </NetworkUnorderedList>
     </div>
   )
 }

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -1,0 +1,44 @@
+// eslint-disable-next-line
+import React from 'react'
+import { getChainName } from '../../adapters'
+import { networks } from './changeNetwork'
+import { Paragraph, Header2 } from '../../ui/shared/Typography'
+
+interface WrongNetworkComponentInterface {
+  currentNetwork: number | undefined,
+  supportedNetworks: number[] | undefined,
+  isMetamask: boolean | null,
+  changeNetwork: (params: any) => void
+}
+
+const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({ supportedNetworks, changeNetwork }) => {
+  if (!supportedNetworks) {
+    return <></>
+  }
+
+  return (
+    <div>
+      <Header2>Incorrect Network</Header2>
+      <Paragraph>
+        {'Please change your wallet to '}
+        {supportedNetworks.length === 1
+          ? <>the following network:</>
+          : <>one of the following networks:</>
+        }
+      </Paragraph>
+
+      <ul>
+        {supportedNetworks.map((chainId: number) =>
+          <li key={chainId}>
+            {networks.get(chainId)
+              ? <button className="changeNetwork" onClick={() => changeNetwork(networks.get(chainId))}>{getChainName(chainId)}</button>
+              : getChainName(chainId)
+            }
+          </li>
+        )}
+      </ul>
+    </div>
+  )
+}
+
+export default WrongNetworkComponent

--- a/src/ux/wrongNetwork/WrongNetworkComponent.tsx
+++ b/src/ux/wrongNetwork/WrongNetworkComponent.tsx
@@ -6,7 +6,6 @@ import { networks } from './changeNetwork'
 import { Paragraph, Header2 } from '../../ui/shared/Typography'
 
 interface WrongNetworkComponentInterface {
-  currentNetwork: number | undefined,
   supportedNetworks: number[] | undefined,
   isMetamask: boolean | null,
   changeNetwork: (params: any) => void
@@ -41,7 +40,7 @@ const NetworkUnorderedList = styled.ul`
 `
 
 const WrongNetworkComponent: React.FC<WrongNetworkComponentInterface> = ({
-  currentNetwork, supportedNetworks, isMetamask, changeNetwork
+  supportedNetworks, isMetamask, changeNetwork
 }) => {
   if (!supportedNetworks) {
     return <></>

--- a/src/ux/wrongNetwork/changeNetwork.ts
+++ b/src/ux/wrongNetwork/changeNetwork.ts
@@ -1,4 +1,15 @@
-import { AddEthereumChainParameter } from '../../lib/provider'
+export interface AddEthereumChainParameter {
+  chainId: string;
+  chainName: string;
+  nativeCurrency: {
+    name: string;
+    symbol: string;
+    decimals: 18;
+  };
+  rpcUrls: string[];
+  blockExplorerUrls?: string[];
+  iconUrls?: string[]; // Currently ignored.
+}
 
 export const networks: Map<number, AddEthereumChainParameter> = new Map([
   [

--- a/src/ux/wrongNetwork/changeNetwork.ts
+++ b/src/ux/wrongNetwork/changeNetwork.ts
@@ -1,0 +1,45 @@
+import { AddEthereumChainParameter } from "../../lib/provider"
+
+// export const networks: [chainId: number, params: AddEthereumChainParameter] = {
+export const networks: Map<number, AddEthereumChainParameter> = new Map([
+  [
+    30, {
+      chainId: '0x1e',
+      chainName: 'RSK Mainnet',
+      nativeCurrency: {
+        name: 'RSK BTC',
+        symbol: 'RBTC',
+        decimals: 18
+      },
+      rpcUrls: ['https://public-node.rsk.co'],
+      blockExplorerUrls: ['https://explorer.rsk.co']
+    }
+  ],
+  [
+    31, {
+      chainId: '0x1f',
+      chainName: 'RSK Testnet',
+      nativeCurrency: {
+        name: 'Test RSK BTC',
+        symbol: 'tRBTC',
+        decimals: 18
+      },
+      rpcUrls: ['https://public-node.testnet.rsk.co'],
+      blockExplorerUrls: ['https://explorer.testnet.rsk.co']
+    }
+  ]
+])
+
+export const canAddChain = (chainId: number) => {
+  return networks.get(chainId)
+  // const answer = <AddEthereumChainParameter | null> networks[chainId]
+  // return networks.hasOwnProperty!(chainId) ? networks[chainId] : null
+  // return networks[chainId.toString()] || null
+  /*
+  switch (chainId) {
+    case 30: return networks[30]
+    case 31: return networks[31]
+    default: return null
+  }
+  */
+}

--- a/src/ux/wrongNetwork/changeNetwork.ts
+++ b/src/ux/wrongNetwork/changeNetwork.ts
@@ -1,6 +1,5 @@
-import { AddEthereumChainParameter } from "../../lib/provider"
+import { AddEthereumChainParameter } from '../../lib/provider'
 
-// export const networks: [chainId: number, params: AddEthereumChainParameter] = {
 export const networks: Map<number, AddEthereumChainParameter> = new Map([
   [
     30, {
@@ -29,17 +28,3 @@ export const networks: Map<number, AddEthereumChainParameter> = new Map([
     }
   ]
 ])
-
-export const canAddChain = (chainId: number) => {
-  return networks.get(chainId)
-  // const answer = <AddEthereumChainParameter | null> networks[chainId]
-  // return networks.hasOwnProperty!(chainId) ? networks[chainId] : null
-  // return networks[chainId.toString()] || null
-  /*
-  switch (chainId) {
-    case 30: return networks[30]
-    case 31: return networks[31]
-    default: return null
-  }
-  */
-}

--- a/src/ux/wrongNetwork/changeNetwork.ts
+++ b/src/ux/wrongNetwork/changeNetwork.ts
@@ -11,7 +11,8 @@ export const networks: Map<number, AddEthereumChainParameter> = new Map([
         decimals: 18
       },
       rpcUrls: ['https://public-node.rsk.co'],
-      blockExplorerUrls: ['https://explorer.rsk.co']
+      blockExplorerUrls: ['https://explorer.rsk.co'],
+      iconUrls: ['https://developers.rsk.co/assets/img/favicons/android-chrome-192x192.png']
     }
   ],
   [
@@ -24,7 +25,8 @@ export const networks: Map<number, AddEthereumChainParameter> = new Map([
         decimals: 18
       },
       rpcUrls: ['https://public-node.testnet.rsk.co'],
-      blockExplorerUrls: ['https://explorer.testnet.rsk.co']
+      blockExplorerUrls: ['https://explorer.testnet.rsk.co'],
+      iconUrls: ['https://developers.rsk.co/assets/img/favicons/android-chrome-192x192.png']
     }
   ]
 ])


### PR DESCRIPTION
Changes the error when a user attempts to connect to an incorrect network. If the user is using Metamask, and one of the available networks is RSK, an option to connect (or configure) that network is presented:

<img width="456" alt="Screen Shot 2021-04-27 at 4 26 09 PM" src="https://user-images.githubusercontent.com/766679/116249238-47a5ea00-a775-11eb-8872-d9c321680482.png">

If the user is not using metamask, the popup remains similar but the popup style is changed:
<img width="462" alt="Screen Shot 2021-04-27 at 4 27 23 PM" src="https://user-images.githubusercontent.com/766679/116249395-73c16b00-a775-11eb-873c-59751ee09456.png">

This should resolve #35, as instead of switching back to step1, it continues. 

Resolves #33 by adding Ethereum testnet names.