### PR TITLE
Retry auth when challenge has expired

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "rLogin - the web3.0 SDK",
   "main": "dist/main.js",
   "files": [

--- a/sample/back/index.js
+++ b/sample/back/index.js
@@ -19,9 +19,17 @@ app.use(bodyParser.json())
 
 const permissioned = process.argv.length > 2 && process.argv[2] === 'permissioned'
 
+const didAuthConfig = {
+  serviceDid,
+  serviceSigner,
+  serviceUrl,
+  challengeSecret,
+}
+
 const authMiddleware = !permissioned
-  ? didAuth.default({ serviceDid, serviceSigner, serviceUrl, challengeSecret })(app)
-  : didAuth.default({ serviceDid, serviceSigner, serviceUrl, challengeSecret,
+  ? didAuth.default(didAuthConfig)(app)
+  : didAuth.default({
+    ...didAuthConfig,
     requiredCredentials: ['Email'],
     requiredClaims: ['Name'],
     signupBusinessLogic: (payload) => { console.log(payload); return true; }


### PR DESCRIPTION
<!--
  Welcome to RIF Identity!
  Please follow this guidelines to make your PR
  https://developers.rsk.co/rif/identity/contribute/
-->

When backend sends error `INVALID_CHALLENGE_RESPONSE` rLogin will first fetch another challenge and try to sign it again. If that fails, error is displayed.
