### PR TITLE
Adds minimal support for Portis

### DIFF
--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -40,6 +40,7 @@
 
     <script src="http://localhost:3005/main.js"></script>
     <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js"></script>
+    <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js"></script>
 
     <script type="text/javascript">
       if (window.ethereum) {
@@ -70,7 +71,17 @@
                 31: 'https://public-node.testnet.rsk.co',
               }
             }
-          }
+          },
+          portis: {
+            package: Portis, // required
+            options: {
+              id: "34616571-d57b-4805-868b-2dcc7b7662d7", // required
+              network: {
+                nodeUrl: 'https://public-node.rsk.co',
+                chainId: 30,
+              }
+            }
+          },
         },
         backendUrl,
         supportedChains: [1, 30, 31]

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -77,8 +77,8 @@
             options: {
               id: "34616571-d57b-4805-868b-2dcc7b7662d7", // required
               network: {
-                nodeUrl: 'https://public-node.rsk.co',
-                chainId: 30,
+                nodeUrl: 'https://public-node.testnet.rsk.co',
+                chainId: 31,
               }
             }
           },

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -101,8 +101,11 @@
       const displayRefreshToken = (refreshToken) => setElementInnerText('refresh-token', refreshToken)
 
       function providerRPC (provider, args) {
-        return provider.request(args)
+        return provider.request
+          ? provider.request(args)
+          : provider.send(args.method, args.params)
       }
+
       // json rpc methods
       const getAccounts = (provider) => providerRPC(provider, { method: 'eth_accounts' })
       const getNetwork = (provider) => providerRPC(provider, { method: 'net_version' }).then(parseInt)

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -268,6 +268,11 @@ export class Core extends React.Component<IModalProps, IModalState> {
     // send disconnect method to wallet connect
     this.disconnectWC(provider)
 
+    // portis
+    if (provider.isPortis) {
+      provider._portis.logout()
+    }
+
     localStorage.removeItem(RLOGIN_ACCESS_TOKEN)
     localStorage.removeItem(RLOGIN_REFRESH_TOKEN)
     localStorage.removeItem('WEB3_CONNECT_CACHED_PROVIDER')

--- a/src/lib/did-auth.ts
+++ b/src/lib/did-auth.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { EIP1193Provider, personalSign } from './provider'
+import { GenericProvider, personalSign } from './provider'
 import { verifyDidJwt } from './jwt'
 import { SD } from './sdr'
 
@@ -30,7 +30,7 @@ const storeAuthData = ({ data }: { data: { refreshToken: string, accessToken: st
 }
 
 export const confirmAuth = (
-  provider: EIP1193Provider,
+  provider: GenericProvider,
   address: string,
   backendUrl: string,
   did: string,

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -30,14 +30,14 @@ export const ethChainId = (provider: GenericProvider) =>
     ? provider.request<string>({ method: 'eth_chainId' })
     : provider.send('eth_chainId')
 
-export const personalSign = (provider: GenericProvider, address: string, data: string) => {
-  return (provider.isPortis)
+export const personalSign = (provider: GenericProvider, address: string, data: string) =>
+  (provider.isPortis)
     ? new Promise((resolve, reject) => provider.send(
       { method: 'personal_sign', params: [utf8ToHex(data), address] },
       (err: Error, res: { result: string }) => err ? reject(err) : resolve(res.result)
     ))
     : provider.request({ method: 'personal_sign', params: [data, address] })
-}
+
 
 export const addEthereumChain = (provider: EIP1193Provider, params: AddEthereumChainParameter) => provider.request({ method: 'wallet_addEthereumChain', params: [params] })
 

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,4 +1,5 @@
 import { AddEthereumChainParameter } from '../ux/wrongNetwork/changeNetwork'
+import { utf8ToHex } from 'web3-utils'
 
 // https://eips.ethereum.org/EIPS/eip-1193
 interface RequestArguments {
@@ -13,7 +14,8 @@ export interface EIP1193Provider {
 }
 
 export interface OlderProvider {
-  send(param: string): Promise<any>
+  send(param: string | { method: string, params: string[]}, callback?: ((err: Error, res: any) => void) | undefined): Promise<any>
+  isPortis: boolean | null
 }
 
 export interface GenericProvider extends EIP1193Provider, OlderProvider {}
@@ -28,7 +30,15 @@ export const ethChainId = (provider: GenericProvider) =>
     ? provider.request<string>({ method: 'eth_chainId' })
     : provider.send('eth_chainId')
 
-export const personalSign = (provider: EIP1193Provider, address: string, data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
+export const personalSign = (provider: GenericProvider, address: string, data: string) => {
+  return (provider.isPortis)
+    ? new Promise((resolve, reject) => provider.send(
+      { method: 'personal_sign', params: [utf8ToHex(data), address] },
+      (err: Error, res: { result: string }) => err ? reject(err) : resolve(res.result)
+    ))
+    : provider.request({ method: 'personal_sign', params: [data, address] })
+}
+
 export const addEthereumChain = (provider: EIP1193Provider, params: AddEthereumChainParameter) => provider.request({ method: 'wallet_addEthereumChain', params: [params] })
 
 export const isMetamask = (provider: EIP1193Provider) => provider.isMetaMask && !provider.isNiftyWallet

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -12,8 +12,22 @@ export interface EIP1193Provider {
   isNiftyWallet: boolean | null
 }
 
-export const ethAccounts = (provider: EIP1193Provider) => provider.request<string[]>({ method: 'eth_accounts' })
-export const ethChainId = (provider: EIP1193Provider) => provider.request<string>({ method: 'eth_chainId' })
+export interface OlderProvider {
+  send(param: string): Promise<any>
+}
+
+export interface GenericProvider extends EIP1193Provider, OlderProvider {}
+
+export const ethAccounts = (provider: GenericProvider) =>
+  provider.request
+    ? provider.request<string[]>({ method: 'eth_accounts' })
+    : provider.send('eth_accounts')
+
+export const ethChainId = (provider: GenericProvider) =>
+  provider.request
+    ? provider.request<string>({ method: 'eth_chainId' })
+    : provider.send('eth_chainId')
+
 export const personalSign = (provider: EIP1193Provider, address: string, data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
 export const addEthereumChain = (provider: EIP1193Provider, params: AddEthereumChainParameter) => provider.request({ method: 'wallet_addEthereumChain', params: [params] })
 

--- a/src/ui/shared/Loading.tsx
+++ b/src/ui/shared/Loading.tsx
@@ -1,0 +1,52 @@
+// adapted from: https://github.com/LucasBassetti/react-css-loaders/blob/master/lib/bubble-spin/BubbleSpin.jsx
+import styled, { css, keyframes } from 'styled-components'
+
+const loading = keyframes`
+  0%,
+  100% {
+    box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+  }
+  12.5% {
+    box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  25% {
+    box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  37.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  50% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  62.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+  }
+  75% {
+    box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+  }
+  87.5% {
+    box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+  }
+`
+
+type BubbleSpinInterface = {
+  size: number
+  color?: string,
+}
+
+const animationMixin = css`${loading} 1s infinite linear;`
+
+const BubbleSpin = styled.div`
+  animation: ${animationMixin};
+  border-radius: 50%;
+  color: ${(props: BubbleSpinInterface) => props.color};
+  font-size: ${(props: BubbleSpinInterface) => `${props.size}px`};
+  height: 1em;
+  margin: 100px auto;
+  position: relative;
+  text-indent: -9999em;
+  transform: translateZ(0);
+  width: 1em;
+`
+
+export default BubbleSpin

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -1,10 +1,11 @@
 // eslint-disable-next-line
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Provider } from './Provider'
 import { IProviderUserOptions } from 'web3modal'
 import { Header2, Paragraph } from '../../ui/shared/Typography'
 import { PROVIDERS_WRAPPER_CLASSNAME, ANCHOR_CLASSNAME, PROVIDERS_FOOTER_TEXT_CLASSNAME } from '../../constants/cssSelectors'
+import Loading from '../../ui/shared/Loading'
 
 interface IWalletProvidersProps {
   userProviders: IProviderUserOptions[]
@@ -28,26 +29,44 @@ const NoWalletAnchor = styled.a`
   }
 `
 
-export const WalletProviders = ({ userProviders }: IWalletProvidersProps) => <>
-  <Header2>Connect your wallet</Header2>
-  <ProvidersWrapper className={PROVIDERS_WRAPPER_CLASSNAME}>
-    {userProviders.map(provider =>
-      provider ? (
-        <Provider
-          key={provider.name}
-          name={provider.name}
-          logo={provider.logo}
-          description={provider.description}
-          onClick={provider.onClick}
-        />
-      ) : null
-    )}
-  </ProvidersWrapper>
-  <Paragraph className={PROVIDERS_FOOTER_TEXT_CLASSNAME}>
-    No wallet?
-    {' '}
-    <NoWalletAnchor href="https://developers.rsk.co/wallet/use/" target="_blank" className={ANCHOR_CLASSNAME}>
-      Get one here!
-    </NoWalletAnchor>
-  </Paragraph>
-</>
+export const WalletProviders = ({ userProviders }: IWalletProvidersProps) => {
+  const [waitingForProvider, setWaitingForProvider] = useState<boolean>(false)
+
+  // return function is for when the component unmounts
+  useEffect(() => {
+    return () => setWaitingForProvider(false)
+  }, [])
+
+  const handleOnClick = (provider: any) => {
+    setWaitingForProvider(true)
+    return provider.onClick().catch(() => setWaitingForProvider(false))
+  }
+
+  return (
+    waitingForProvider
+      ? <Loading size={10} color="#008FF7" />
+      : <>
+        <Header2>Connect your wallet</Header2>
+        <ProvidersWrapper className={PROVIDERS_WRAPPER_CLASSNAME}>
+          {userProviders.map(provider =>
+            provider ? (
+              <Provider
+                key={provider.name}
+                name={provider.name}
+                logo={provider.logo}
+                description={provider.description}
+                onClick={() => handleOnClick(provider)}
+              />
+            ) : null
+          )}
+        </ProvidersWrapper>
+        <Paragraph className={PROVIDERS_FOOTER_TEXT_CLASSNAME}>
+        No wallet?
+          {' '}
+          <NoWalletAnchor href="https://developers.rsk.co/wallet/use/" target="_blank" className={ANCHOR_CLASSNAME}>
+          Get one here!
+          </NoWalletAnchor>
+        </Paragraph>
+      </>
+  )
+}


### PR DESCRIPTION
Adds basic support for the first 2 flavors of rLogin to Portis. Portis is not an EIP1193 provider and relies on the deprecated `send` and `sendAsync` functions. For retrieving the chainId and addresses, `send().then()` works without issue. However, Portis requires the `sign` method to use a callback. 

At the current state, since Portis is not an EIP1193 provider, a dapp could use rLogin with Portis, but they would need to make sure their functions support the .send/sendasync methods.

**flavors**

1. Allows rLogin to pass the `provider` through when using rLogin's flavor 1.
2. Allows a user to sign a message owning a DID, i.e. flavor 2.
3. In theory the 3rd flavor of rLogin (i.e. connecting the the DV and getting DD and Creds) should work. However, modifications to the Rif Id Manager, and Email VC issuer would need to be done to insert the data.

**misc**

It also adds a loading wheel after the user has selected a provider. Portis sometimes takes a while to load and this lets the user know that it is in progress. 
