### PR TITLE
Check if provider is set first, then disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "rLogin - the web3.0 SDK",
   "main": "dist/main.js",
   "files": [

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -264,7 +264,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
    * @param provider web3 Provider
    */
   private disconnectWC (provider: any): void {
-    if (provider.wc) {
+    if (provider && provider.wc) {
       provider.disconnect()
       localStorage.removeItem(WALLETCONNECT)
     }


### PR DESCRIPTION
Fixes an issue where the modal will not close when the provider is undefined. 