### PR TITLE
Show message if there are no providers

### DIFF
--- a/src/providers/injectedProviders.ts
+++ b/src/providers/injectedProviders.ts
@@ -36,8 +36,8 @@ const injectedProviders = [
  * @returns updated array of providers
  */
 export const checkRLoginInjectedProviders = (providers: IProviderUserOptions[]) => {
-  // if the first item is not Web3 or Metamask return the array
-  if (providers[0].name !== 'Web3' && providers[0].name !== 'MetaMask') {
+  // if zero items, or the first item is not Web3 or Metamask return the array
+  if (providers.length === 0 || (providers[0].name !== 'Web3' && providers[0].name !== 'MetaMask')) {
     return providers
   }
 

--- a/src/ux/step1/WalletProviders.test.tsx
+++ b/src/ux/step1/WalletProviders.test.tsx
@@ -33,4 +33,9 @@ describe('Component: WalletProviders', () => {
     expect(wrapper.find(`div.${PROVIDERS_WRAPPER_CLASSNAME}`).childAt(0).find('h3').text()).toEqual('test1')
     expect(wrapper.find(`div.${PROVIDERS_WRAPPER_CLASSNAME}`).childAt(1).find('h3').text()).toEqual('test2')
   })
+
+  it('shows message about no providers', () => {
+    const wrapper = mount(<WalletProviders {...props} userProviders={[]} />)
+    expect(wrapper.find('h2').text()).toBe('No wallets found')
+  })
 })

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -30,7 +30,9 @@ const NoWalletAnchor = styled.a`
 `
 
 export const WalletProviders = ({ userProviders, setLoading }: IWalletProvidersProps) => <>
-  <Header2>Connect your wallet</Header2>
+  <Header2>
+    {userProviders.length !== 0 ? 'Connect your wallet' : 'No wallets found'}
+  </Header2>
   <ProvidersWrapper className={PROVIDERS_WRAPPER_CLASSNAME}>
     {userProviders.map(provider =>
       provider ? (


### PR DESCRIPTION
Return empty string if there are no providers rather than checking if the non-existent one. Then update the UI to show a message about no providers. 

To test this, remove WalletConnect and Portis as providerOptions in `/sample/front/index.html` then disable Metamask from chrome. Start the app using `npm run sample:open. With zero providers, you should now see this message:

![Screen Shot 2021-07-28 at 2 16 54 PM](https://user-images.githubusercontent.com/766679/127313728-ea6f87a9-e21a-4fbd-93b4-bca0c1db7cba.png)


Resolves #104, reported by @antomor