### PR TITLE
(US-93) feat: enable 'supportedLanguages' options

### DIFF
--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -61,7 +61,7 @@
       // supportedChains parameter
       const defaultNetworks = [1,30,31]
       const supportedChainsParam = new URLSearchParams(window.location.search).get('supportedChains')
-      const supportedChains = !supportedChainsParam ? 
+      const supportedChains = !supportedChainsParam ?
         defaultNetworks :
         (supportedChainsParam == 'all'? null : supportedChainsParam.split(',').map(chain => parseInt(chain)))
 
@@ -100,6 +100,7 @@
         backendUrl,
         keepModalHidden,
         supportedChains,
+        supportedLanguages: ['es','en'],
         dataVaultOptions: {
           package:RIFDataVault,
           serviceUrl: 'https://data-vault.identity.rifos.org',

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -174,8 +174,6 @@ export class Core extends React.Component<IModalProps, IModalState> {
     return this.validateCurrentChain()
   }
 
-
-
   private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => { if (success) { return this.detectFlavor() } })
 
   private validateCurrentChain ():boolean {

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -74,6 +74,11 @@ interface ErrorDetails {
   description?: string
 }
 
+interface IAvailableLanguage {
+  code: string
+  name: string
+}
+
 interface IModalState {
   show: boolean
   currentStep: Step
@@ -118,9 +123,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
     this.onConfirmAuth = this.onConfirmAuth.bind(this)
     this.disconnect = this.disconnect.bind(this)
     this.connectToWallet = this.connectToWallet.bind(this)
-    if (this.props.supportedLanguages) {
-      this.availableLanguages = this.availableLanguages.filter(availableLanguage => this.props.supportedLanguages?.includes(availableLanguage.code))
-    }
+    this.availableLanguages = []
+    this.setupLanguages()
   }
 
   public state: IModalState = {
@@ -129,6 +133,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
   public lightboxRef?: HTMLDivElement | null;
   public mainModalCard?: HTMLDivElement | null;
+  private availableLanguages: IAvailableLanguage[];
 
   public componentDidUpdate (prevProps: IModalProps, prevState: IModalState) {
     if (prevState.show && !this.state.show) {
@@ -147,6 +152,14 @@ export class Core extends React.Component<IModalProps, IModalState> {
     }
   }
 
+  private setupLanguages () {
+    // this fetches all available languages in this form [{en:english},...]
+    const availableLanguages = Object.entries(i18next.services.resourceStore.data).map(keyValueLanguage => { return { code: keyValueLanguage[0], name: keyValueLanguage[1].name.toString() } })
+    if (this.props.supportedLanguages) {
+      this.availableLanguages = availableLanguages.filter(availableLanguage => this.props.supportedLanguages?.includes(availableLanguage.code))
+    }
+  }
+
   /** accounts related */
   private did () {
     return this.state.chainId && this.state.address ? getDID(this.state.chainId, this.state.address) : ''
@@ -161,8 +174,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     return this.validateCurrentChain()
   }
 
-  // this fetches all available languages in this form [{en:english},...]
-  private availableLanguages = Object.entries(i18next.services.resourceStore.data).map(keyValueLanguage => { return { code: keyValueLanguage[0], name: keyValueLanguage[1].name.toString() } })
+
 
   private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => { if (success) { return this.detectFlavor() } })
 

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -63,6 +63,7 @@ interface IModalProps {
   backendUrl?: string
   keepModalHidden?: boolean
   supportedChains?: number[]
+  supportedLanguages?: string[]
   dataVaultOptions?: DataVaultOptions
 }
 
@@ -117,6 +118,9 @@ export class Core extends React.Component<IModalProps, IModalState> {
     this.onConfirmAuth = this.onConfirmAuth.bind(this)
     this.disconnect = this.disconnect.bind(this)
     this.connectToWallet = this.connectToWallet.bind(this)
+    if (this.props.supportedLanguages) {
+      this.availableLanguages = this.availableLanguages.filter(availableLanguage => this.props.supportedLanguages?.includes(availableLanguage.code))
+    }
   }
 
   public state: IModalState = {

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -34,6 +34,7 @@ interface RLoginOptions {
   backendUrl?: string
   keepModalHidden?: boolean
   supportedChains?: number[]
+  supportedLanguages?: string[]
   dataVaultOptions?: DataVaultOptions
 }
 
@@ -45,6 +46,7 @@ export class RLogin {
   private providerController: ProviderController;
   private userProviders: IProviderUserOptions[];
   private supportedChains?: number[];
+  private supportedLanguages?: string[];
   private backendUrl?: string;
   private keepModalHidden: boolean;
   private dataVaultOptions?: DataVaultOptions
@@ -64,6 +66,7 @@ export class RLogin {
     })
 
     this.supportedChains = opts && opts.supportedChains
+    this.supportedLanguages = opts && opts.supportedLanguages
 
     // setup did auth
     this.backendUrl = opts && opts.backendUrl
@@ -146,6 +149,7 @@ export class RLogin {
         onChainChange={this.onChainChange}
         backendUrl={this.backendUrl}
         supportedChains={this.supportedChains}
+        supportedLanguages={this.supportedLanguages}
         keepModalHidden={this.keepModalHidden}
         dataVaultOptions={this.dataVaultOptions}
       />,


### PR DESCRIPTION
User can optionally set supported languages in the options object when initializing rLogin. If option `supportedLanguages` is not defined, all languages are supported by default.