### PR TITLE
Make modal do not disconnect from Ledger on close

### DIFF
--- a/cypress/integration/1-modal/rlogin-modal_spec.js
+++ b/cypress/integration/1-modal/rlogin-modal_spec.js
@@ -9,7 +9,7 @@ describe('rLoign modal interaction', () => {
   })
 
   it('closes the popup when clicking outside of it', () => {
-    cy.get('body').click()
+    cy.get('.rlogin-modal-container').click('topRight')
     cy.get('.rlogin-modal-lightbox').should('be.not.visible')
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rlogin",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "rLogin - the web3.0 SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -44,7 +44,7 @@
     <script src="http://localhost:3005/index.js"></script>
     <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js"></script>
     <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js"></script>
-    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.0-beta.5/dist/bundle.js"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.0-beta.6/dist/bundle.js"></script>
     <script src="https://unpkg.com/@rsksmart/ipfs-cpinner-client@0.1.3/dist/bundle.js"></script>
 
     <script type="text/javascript">

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -44,6 +44,7 @@
     <script src="http://localhost:3005/index.js"></script>
     <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js"></script>
     <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.0-beta.5/dist/bundle.js"></script>
     <script src="https://unpkg.com/@rsksmart/ipfs-cpinner-client@0.1.3/dist/bundle.js"></script>
 
     <script type="text/javascript">
@@ -96,6 +97,13 @@
               }
             }
           },
+          'custom-ledger': {
+            ...window.rLoginLedgerProvider.ledgerProviderOptions,
+            options: {
+              rpcUrl: 'https://public-node.testnet.rsk.co',
+              chainId: 31
+            }
+          }
         },
         backendUrl,
         keepModalHidden,
@@ -187,7 +195,7 @@
             .then(from => sign(provider, [message, from]))
             .then(signature => {
               setElementInnerText('signature', signature)
-              return ecRecover(provider, [message, signature])
+              return ecRecover(provider, [message, signature]).catch(e => e.message)
             })
             .then(recovery => setElementInnerText('recovery', recovery))
             .catch(handleError)

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -152,7 +152,10 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
   public componentDidUpdate (prevProps: IModalProps, prevState: IModalState) {
     if (prevState.show && !this.state.show) {
-      this.disconnect()
+      // this is making the Ledger disconnect when the popup is closed after connecting
+      // for now, we can comment it out. let's understand how to make a 'cancel' button
+      // or simmilar
+      // this.disconnect()
     }
     if (this.lightboxRef) {
       const lightboxRect = this.lightboxRef.getBoundingClientRect()

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -154,7 +154,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     // this is making the Ledger disconnect when the popup is closed after connecting
     // for now, we can comment it out. let's understand how to make a 'cancel' button
     // or simmilar
-    if (prevState.show && !this.state.show && (!!this.state.provider && this.state.provider.isLedger)) {
+    if (prevState.show && !this.state.show && !!this.state.provider && !this.state.provider.isLedger) {
       this.disconnect()
     }
     if (this.lightboxRef) {

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -154,7 +154,10 @@ export class Core extends React.Component<IModalProps, IModalState> {
     // this is making the Ledger disconnect when the popup is closed after connecting
     // for now, we can comment it out. let's understand how to make a 'cancel' button
     // or simmilar
-    if (prevState.show && !this.state.show && !!this.state.provider && !this.state.provider.isLedger) {
+    if (
+      prevState.show && !this.state.show &&
+      (!this.state.provider || !this.state.provider.isLedger)
+    ) {
       this.disconnect()
     }
     if (this.lightboxRef) {

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -151,14 +151,13 @@ export class Core extends React.Component<IModalProps, IModalState> {
   }
 
   public componentDidUpdate (prevProps: IModalProps, prevState: IModalState) {
-    // this is making the Ledger disconnect when the popup is closed after connecting
-    // for now, we can comment it out. let's understand how to make a 'cancel' button
-    // or simmilar
-    if (
-      prevState.show && !this.state.show &&
-      (!this.state.provider || !this.state.provider.isLedger)
+    // this resets the state if an unhandled error closed the modal
+
+    if (this.state.currentStep === 'loading' &&
+      !prevState.show && this.state.show
     ) {
-      this.disconnect()
+      this.disconnectProvider()
+      this.setState({ currentStep: 'Step1' })
     }
     if (this.lightboxRef) {
       const lightboxRect = this.lightboxRef.getBoundingClientRect()

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -151,11 +151,11 @@ export class Core extends React.Component<IModalProps, IModalState> {
   }
 
   public componentDidUpdate (prevProps: IModalProps, prevState: IModalState) {
-    if (prevState.show && !this.state.show) {
-      // this is making the Ledger disconnect when the popup is closed after connecting
-      // for now, we can comment it out. let's understand how to make a 'cancel' button
-      // or simmilar
-      // this.disconnect()
+    // this is making the Ledger disconnect when the popup is closed after connecting
+    // for now, we can comment it out. let's understand how to make a 'cancel' button
+    // or simmilar
+    if (prevState.show && !this.state.show && (!!this.state.provider && this.state.provider.isLedger)) {
+      this.disconnect()
     }
     if (this.lightboxRef) {
       const lightboxRect = this.lightboxRef.getBoundingClientRect()

--- a/src/ui/modal/Modal.tsx
+++ b/src/ui/modal/Modal.tsx
@@ -33,7 +33,6 @@ export const Modal: React.FC<ModalProps> = ({
     show={show}
   >
     <ModalContainer show={show}>
-      {/* TODO: test this component hitting outside the modal */}
       <ModalHitbox className={MODAL_HITBOX_CLASSNAME} onClick={onClose} />
       <ModalCard mainModalCard={mainModalCard}>
         <ModalHeader className={MODAL_HEADER_CLASSNAME}>


### PR DESCRIPTION
This made Ledger provider fail. As far as I remember, this was added to make the modal restart on closed manually. This is now a blocker, we can find a better strategy to do this latter.
