### PR TITLE
Choose network for hardware wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following methods are confirmed to work: `eth_chainId`, `eth_accounts`, `net
     
     > Sample: https://github.com/rsksmart/rif-identity-manager/blob/main/src/helpers.ts
 
-### Flavors
+## Flavors
 
 - Fully-decentralized apps: this kind of apps are used only client-side. The front-end will need to know user's address and information for presentational purposes. The core operations are performed using blockchain transactions.
 
@@ -247,12 +247,33 @@ The Cypress tests can also be run in a headless browser by running the command:
 npm run cypress:run
 ```
 
-## Multi-language
+## Additional Features
+
+### Multi-language
 Please take a look at the following file to add more languages:
 ```
 /src/i18n.ts
 ```
+### Choose network for hardware wallets
 
+A dapp and hardware wallet could support multiple networks so to help users, a middle step has been added to choose the network. To enable this, the developer needs to add fallback chains. Below is an example of how a developer would add Ledger with the network choose:
+
+```
+const rLogin = new window.RLogin.default({
+  cacheProvider: false,
+  providerOptions: {
+    'custom-ledger': {
+      ...window.rLoginLedgerProvider.ledgerProviderOptions,
+    }
+  },
+  rpcUrls: {
+    30: 'https://public-node.rsk.co',
+    31: 'https://public-node.testnet.rsk.co'
+  }
+}
+```
+
+In this case, the RPC Url and ChainId parameters do not need to be added in the providerOptions section.
 
 ## Sample apps
 

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -43,10 +43,19 @@
 
     <script src="http://localhost:3005/index.js"></script>
 
-    <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js"></script>
-    <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js"></script>
-    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.0-beta.6/dist/bundle.js"></script>
-    <script src="https://unpkg.com/@rsksmart/ipfs-cpinner-client@0.1.3/dist/bundle.js"></script>
+    <!-- Mobile -->
+    <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js" integrity="sha384-e1LVDbPXlpouaOa/B5TOOA/EeKsLWbCQpRC6XB5RBn0eKI8E1msrTnw8Dvkft020" crossorigin="anonymous"></script>
+
+    <!-- Custodial -->
+    <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js" integrity="sha384-rVrQx3OPQbx/BulpfW0MLzID/fIM+x2qiI9Ibhpgd8MKK7wqsVPRRLDMQDWU7zS3" crossorigin="anonymous"></script>
+
+    <!-- Hardware -->
+    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.0-beta.8/dist/bundle.js" integrity="sha384-m/q7N5NZG7fIxx00ult4A74N/jPFwgG564OiwXPPXpdHzu1i5BAyxPA4535U/Yqs" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-trezor-provider@1.0.0-beta.9/dist/bundle.js" integrity="sha384-rr3MHx1XrgmOTDi1vXLwgGmAr5U7UXddzRRZNwU53MWO817EY6yucdp4imrHdMeD" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-dcent-provider@1.0.0-beta.8/dist/bundle.js" integrity="sha384-Zt1JFaeCbx2cs8Cu7N/4gYXPBB33TlqZoJlqboFo+vJuerwJcOGWzm2Xd8lpOWG2" crossorigin="anonymous"></script>
+
+    <!-- RIF Data Vault Client -->
+    <script src="https://unpkg.com/@rsksmart/ipfs-cpinner-client@0.1.3/dist/bundle.js" integrity="sha384-Vqy7eKjwpV8AMv0kkeflaAUxoUgdOyjYJ3sNfEHOdptoaF8NuOFl0Ag/g0HChrCn" crossorigin="anonymous"></script>
 
     <script type="text/javascript">
       if (window.ethereum) {
@@ -100,7 +109,15 @@
           },
           'custom-ledger': {
             ...window.rLoginLedgerProvider.ledgerProviderOptions,
-          }
+          },
+          'custom-trezor': {
+            ...window.rLoginTrezorProvider.trezorProviderOptions,
+            manifestEmail: 'info@iovlabs.org',
+            manifestAppUrl: 'https://basic-sample.rlogin.identity.rifos.org/',
+          },
+          'custom-dcent': {
+            ...window.rLoginDCentProvider.dcentProviderOptions,
+          },
         },
         backendUrl,
         keepModalHidden,

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -100,10 +100,6 @@
           },
           'custom-ledger': {
             ...window.rLoginLedgerProvider.ledgerProviderOptions,
-            options: {
-              rpcUrl: 'https://public-node.testnet.rsk.co',
-              chainId: 31
-            }
           }
         },
         backendUrl,
@@ -114,6 +110,11 @@
           package:RIFDataVault,
           serviceUrl: 'https://data-vault.identity.rifos.org',
         },
+        rpcUrls: {
+          1: 'https://mainnet.infura.io/v3/8043bb2cf99347b1bfadfb233c5325c0',
+          30: 'https://public-node.rsk.co',
+          31: 'https://public-node.testnet.rsk.co'
+        }
         // customThemes: {light:{modalBackground:'#ff0000'}},
         // defaultTheme: 'dark'
       })

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -252,7 +252,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
     // choose the network first:
     const { rpcUrls } = this.props
-    if (['Ledger', 'Trezor', 'Dcent'].includes(provider.name) && rpcUrls) {
+    if (['Ledger', 'Trezor', 'D\'Cent'].includes(provider.name) && rpcUrls) {
       return this.setState({ currentStep: 'chooseNetwork' })
     }
 

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -247,10 +247,12 @@ export class Core extends React.Component<IModalProps, IModalState> {
    * @param provider The provider selected by the user to use
    */
   private preConnectChecklist = (provider: RLoginIProviderUserOptions) => {
+    // temporarly set the provider to be used when the choose network component returns
+    this.setState({ provider })
+
     // choose the network first:
-    if (['Ledger', 'Trezor', 'Dcent'].includes(provider.name)) {
-      // temporarly set the provider to be used when the choose network component returns
-      this.setState({ provider })
+    const { rpcUrls } = this.props
+    if (['Ledger', 'Trezor', 'Dcent'].includes(provider.name) && rpcUrls) {
       return this.setState({ currentStep: 'chooseNetwork' })
     }
 

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -260,8 +260,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
   }
 
   /** Pre-Step 1 - user picked a wallet, and network and waiting to connect */
-  private connectToWallet (provider: RLoginIProviderUserOptions, networkoptions?: { chainId: number, rpcUrl: string }) {
-    provider.onClick(networkoptions)
+  private connectToWallet (providerUserOption: RLoginIProviderUserOptions, networkoptions?: { chainId: number, rpcUrl: string }) {
+    providerUserOption.onClick(networkoptions)
     this.setState({
       currentStep: 'loading',
       loadingReason: 'Connecting to provider',

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -26,6 +26,7 @@ import i18n from './i18n'
 import { ThemeProvider } from 'styled-components'
 import { ThemeType, themesOptions } from './theme'
 import { ConfirmInformation } from './ux/confirmInformation/ConfirmInformation'
+import ChooseNetworkComponent from './ux/chooseNetwork/ChooseNetworkComponent'
 
 // copy-pasted and adapted
 // https://github.com/Web3Modal/web3modal/blob/4b31a6bdf5a4f81bf20de38c45c67576c3249bfc/src/components/Modal.tsx
@@ -72,9 +73,10 @@ interface IModalProps {
   // eslint-disable-next-line no-unused-vars
   themes: { [K in themesOptions]: ThemeType }
   defaultTheme: themesOptions
+  rpcUrls?: {[key: string]: string}
 }
 
-type Step = 'Step1' | 'Step2' | 'ConfirmInformation' | 'error' | 'wrongNetwork' | 'loading'
+type Step = 'Step1' | 'Step2' | 'ConfirmInformation' | 'error' | 'wrongNetwork' | 'chooseNetwork' | 'loading'
 
 interface ErrorDetails {
   title: string
@@ -393,7 +395,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
   public render = () => {
     const { show, lightboxOffset, currentStep, sd, sdr, chainId, address, errorReason, provider, selectedProviderUserOption, loadingReason } = this.state
-    const { onClose, userProviders, backendUrl, providerController, supportedChains, themes } = this.props
+    const { onClose, userProviders, backendUrl, providerController, supportedChains, themes, rpcUrls } = this.props
 
     /**
      * handleClose is fired when the modal or providerModal is closed by the user
@@ -418,11 +420,12 @@ export class Core extends React.Component<IModalProps, IModalState> {
         mainModalCard={this.mainModalCard}
         big={currentStep === 'Step1'}
       >
-        {currentStep === 'Step1' && <WalletProviders userProviders={userProviders} setLoading={this.connectToWallet} changeLanguage={this.changeLanguage} availableLanguages={this.availableLanguages} selectedLanguageCode={this.selectedLanguageCode} changeTheme={this.changeTheme} selectedTheme={this.selectedTheme} />}
+        {currentStep === 'Step1' && <WalletProviders userProviders={userProviders} connectToWallet={this.connectToWallet} changeLanguage={this.changeLanguage} availableLanguages={this.availableLanguages} selectedLanguageCode={this.selectedLanguageCode} changeTheme={this.changeTheme} selectedTheme={this.selectedTheme} />}
         {currentStep === 'Step2' && <SelectiveDisclosure sdr={sdr!} backendUrl={backendUrl!} fetchSelectiveDisclosureRequest={this.fetchSelectiveDisclosureRequest} onConfirm={this.onConfirmSelectiveDisclosure} />}
         {currentStep === 'ConfirmInformation' && <ConfirmInformation chainId={chainId} address={address} provider={provider} providerUserOption={selectedProviderUserOption!} sd={sd} onConfirm={this.onConfirmAuth} onCancel={handleClose} />}
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description}/>}
         {currentStep === 'wrongNetwork' && <WrongNetworkComponent supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
+        {currentStep === 'chooseNetwork' && <ChooseNetworkComponent rpcUrls={rpcUrls} chooseNetwork={(chainId: number, url: string) => console.log(chainId, url)} />}
         {currentStep === 'loading' && <Loading text={loadingReason} />}
       </Modal>
     </ThemeProvider>

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -41,6 +41,7 @@ interface RLoginOptions {
   dataVaultOptions?: DataVaultOptions
   customThemes?: any
   defaultTheme?: themesOptions
+  rpcUrls?: {[key: string]: string}
 }
 
 type Options = Partial<IProviderControllerOptions> & RLoginOptions
@@ -58,6 +59,7 @@ export class RLogin {
   private dataVaultOptions?: DataVaultOptions
   private themes = { ...themesConfig }
   private defaultTheme: themesOptions
+  private rpcUrls?: {[key: string]: string}
 
   constructor (opts?: Options) {
     const options: IProviderControllerOptions = {
@@ -75,6 +77,7 @@ export class RLogin {
 
     this.supportedChains = opts && opts.supportedChains
     this.supportedLanguages = opts && opts.supportedLanguages
+    this.rpcUrls = opts && opts.rpcUrls
 
     // setup did auth
     this.backendUrl = opts && opts.backendUrl
@@ -178,6 +181,7 @@ export class RLogin {
         dataVaultOptions={this.dataVaultOptions}
         themes = {this.themes}
         defaultTheme = {this.defaultTheme}
+        rpcUrls={this.rpcUrls}
       />,
       document.getElementById(WEB3_CONNECT_MODAL_ID)
     )

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -6,9 +6,10 @@ import {
   IProviderControllerOptions,
   IProviderUserOptions,
   SimpleFunction,
-  EventController,
-  ProviderController
+  EventController
 } from 'web3modal'
+
+import { RLoginProviderController } from './controllers/providers'
 
 import { CONNECT_EVENT, ERROR_EVENT, CLOSE_EVENT, ACCOUNTS_CHANGED, CHAIN_CHANGED, THEME_CHANGED, LANGUAGE_CHANGED } from './constants/events'
 
@@ -48,7 +49,7 @@ export class RLogin {
   private show: boolean = INITIAL_STATE.show;
   private eventController: EventController = new EventController();
   private rLoginStorage: RLoginStorage = new RLoginStorage();
-  private providerController: ProviderController;
+  private providerController: RLoginProviderController;
   private userProviders: IProviderUserOptions[];
   private supportedChains?: number[];
   private supportedLanguages?: string[];
@@ -65,7 +66,7 @@ export class RLogin {
     }
 
     // setup provider controller
-    this.providerController = new ProviderController({
+    this.providerController = new RLoginProviderController({
       disableInjectedProvider: options.disableInjectedProvider,
       cacheProvider: options.cacheProvider,
       providerOptions: options.providerOptions,

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -1,0 +1,237 @@
+import * as list from "../providers";
+import {
+  CONNECT_EVENT,
+  ERROR_EVENT,
+  INJECTED_PROVIDER_ID,
+  CACHED_PROVIDER_KEY
+} from "../constants";
+import {
+  isMobile,
+  IProviderControllerOptions,
+  IProviderOptions,
+  IProviderDisplayWithConnector,
+  getLocal,
+  setLocal,
+  removeLocal,
+  getProviderInfoById,
+  getProviderDescription,
+  IProviderInfo,
+  filterMatches,
+  IProviderUserOptions,
+  getInjectedProvider,
+  findMatchingRequiredOptions
+} from "../helpers";
+import { EventController } from "./events";
+
+export class ProviderController {
+  public cachedProvider: string = "";
+  public shouldCacheProvider: boolean = false;
+  public disableInjectedProvider: boolean = false;
+
+  private eventController: EventController = new EventController();
+  private injectedProvider: IProviderInfo | null = null;
+  private providers: IProviderDisplayWithConnector[] = [];
+  private providerOptions: IProviderOptions;
+  private network: string = "";
+
+  constructor(opts: IProviderControllerOptions) {
+    this.cachedProvider = getLocal(CACHED_PROVIDER_KEY) || "";
+
+    this.disableInjectedProvider = opts.disableInjectedProvider;
+    this.shouldCacheProvider = opts.cacheProvider;
+    this.providerOptions = opts.providerOptions;
+    this.network = opts.network;
+
+    this.injectedProvider = getInjectedProvider();
+
+    this.providers = Object.keys(list.connectors).map((id: string) => {
+      let providerInfo: IProviderInfo;
+      if (id === INJECTED_PROVIDER_ID) {
+        providerInfo = this.injectedProvider || list.providers.FALLBACK;
+      } else {
+        providerInfo = getProviderInfoById(id);
+      }
+      // parse custom display options
+      if (this.providerOptions[id]) {
+        const options = this.providerOptions[id];
+        if (typeof options.display !== "undefined") {
+          providerInfo = {
+            ...providerInfo,
+            ...this.providerOptions[id].display
+          };
+        }
+      }
+      return {
+        ...providerInfo,
+        connector: list.connectors[id],
+        package: providerInfo.package
+      };
+    });
+    // parse custom providers
+    Object.keys(this.providerOptions)
+      .filter(key => key.startsWith("custom-"))
+      .map(id => {
+        if (id && this.providerOptions[id]) {
+          const options = this.providerOptions[id];
+          if (
+            typeof options.display !== "undefined" &&
+            typeof options.connector !== "undefined"
+          ) {
+            this.providers.push({
+              ...list.providers.FALLBACK,
+              id,
+              ...options.display,
+              connector: options.connector
+            });
+          }
+        }
+      });
+  }
+
+  public shouldDisplayProvider(id: string) {
+    const provider = this.getProvider(id);
+    if (typeof provider !== "undefined") {
+      const providerPackageOptions = this.providerOptions[id];
+      if (providerPackageOptions) {
+        const isProvided = !!providerPackageOptions.package;
+        if (isProvided) {
+          const requiredOptions = provider.package
+            ? provider.package.required
+            : undefined;
+          if (requiredOptions && requiredOptions.length) {
+            const providedOptions = providerPackageOptions.options;
+            if (providedOptions && Object.keys(providedOptions).length) {
+              const matches = findMatchingRequiredOptions(
+                requiredOptions,
+                providedOptions
+              );
+              if (requiredOptions.length === matches.length) {
+                return true;
+              }
+            }
+          } else {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  public getUserOptions = () => {
+    const mobile = isMobile();
+
+    const defaultProviderList = this.providers.map(({ id }) => id);
+
+    const displayInjected =
+      !!this.injectedProvider && !this.disableInjectedProvider;
+    const onlyInjected = displayInjected && mobile;
+
+    const providerList = [];
+
+    if (onlyInjected) {
+      providerList.push(INJECTED_PROVIDER_ID);
+    } else {
+      if (displayInjected) {
+        providerList.push(INJECTED_PROVIDER_ID);
+      }
+
+      defaultProviderList.forEach((id: string) => {
+        if (id !== INJECTED_PROVIDER_ID) {
+          const result = this.shouldDisplayProvider(id);
+          if (result) {
+            providerList.push(id);
+          }
+        }
+      });
+    }
+
+    const userOptions: IProviderUserOptions[] = [];
+
+    providerList.forEach((id: string) => {
+      let provider = this.getProvider(id);
+      if (typeof provider !== "undefined") {
+        const { id, name, logo, connector } = provider;
+        userOptions.push({
+          name,
+          logo,
+          description: getProviderDescription(provider),
+          onClick: () => this.connectTo(id, connector)
+        });
+      }
+    });
+
+    return userOptions;
+  };
+
+  public getProvider(id: string) {
+    return filterMatches<IProviderDisplayWithConnector>(
+      this.providers,
+      x => x.id === id,
+      undefined
+    );
+  }
+
+  public getProviderOption(id: string, key: string) {
+    return this.providerOptions &&
+      this.providerOptions[id] &&
+      this.providerOptions[id][key]
+      ? this.providerOptions[id][key]
+      : {};
+  }
+
+  public clearCachedProvider() {
+    this.cachedProvider = "";
+    removeLocal(CACHED_PROVIDER_KEY);
+  }
+
+  public setCachedProvider(id: string) {
+    this.cachedProvider = id;
+    setLocal(CACHED_PROVIDER_KEY, id);
+  }
+
+  public connectTo = async (
+    id: string,
+    connector: (providerPackage: any, opts: any) => Promise<any>
+  ) => {
+    try {
+      const providerPackage = this.getProviderOption(id, "package");
+      const providerOptions = this.getProviderOption(id, "options");
+      const opts = { network: this.network || undefined, ...providerOptions };
+      const provider = await connector(providerPackage, opts);
+      this.eventController.trigger(CONNECT_EVENT, provider);
+      if (this.shouldCacheProvider && this.cachedProvider !== id) {
+        this.setCachedProvider(id);
+      }
+    } catch (error) {
+      this.eventController.trigger(ERROR_EVENT);
+    }
+  };
+
+  public async connectToCachedProvider() {
+    const provider = this.getProvider(this.cachedProvider);
+    if (typeof provider !== "undefined") {
+      await this.connectTo(provider.id, provider.connector);
+    }
+  }
+
+  public on(event: string, callback: (result: any) => void): () => void {
+    this.eventController.on({
+      event,
+      callback
+    });
+
+    return () =>
+      this.eventController.off({
+        event,
+        callback
+      });
+  }
+
+  public off(event: string, callback?: (result: any) => void): void {
+    this.eventController.off({
+      event,
+      callback
+    });
+  }
+}

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -143,7 +143,7 @@ export class RLoginProviderController {
           name,
           logo,
           description: getProviderDescription(provider),
-          onClick: () => this.connectTo(id, connector)
+          onClick: (opts?: { chainId: number, rpcUrl: string }) => this.connectTo(id, connector, opts)
         })
       }
     })
@@ -179,11 +179,16 @@ export class RLoginProviderController {
 
   public connectTo = async (
     id: string,
-    connector: (providerPackage: any, opts: any) => Promise<any>
+    connector: (providerPackage: any, opts: any) => Promise<any>,
+    optionalOpts?: { chainId?: number, rpcUrl?: string }
   ) => {
     try {
       const providerPackage = this.getProviderOption(id, 'package')
-      const providerOptions = this.getProviderOption(id, 'options')
+      const providerOptions = {
+        ...this.getProviderOption(id, 'options'),
+        ...optionalOpts
+      }
+
       const opts = { network: this.network || undefined, ...providerOptions }
       const provider = await connector(providerPackage, opts)
       this.eventController.trigger(CONNECT_EVENT, provider)

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -1,30 +1,7 @@
-import * as list from "../providers";
-import {
-  CONNECT_EVENT,
-  ERROR_EVENT,
-  INJECTED_PROVIDER_ID,
-  CACHED_PROVIDER_KEY
-} from "../constants";
-import {
-  isMobile,
-  IProviderControllerOptions,
-  IProviderOptions,
-  IProviderDisplayWithConnector,
-  getLocal,
-  setLocal,
-  removeLocal,
-  getProviderInfoById,
-  getProviderDescription,
-  IProviderInfo,
-  filterMatches,
-  IProviderUserOptions,
-  getInjectedProvider,
-  findMatchingRequiredOptions
-} from "../helpers";
-import { EventController } from "./events";
+import { EventController, IProviderInfo, IProviderDisplayWithConnector, IProviderOptions, IProviderControllerOptions, getLocal, CACHED_PROVIDER_KEY, getInjectedProvider, INJECTED_PROVIDER_ID, getProviderInfoById, findMatchingRequiredOptions, isMobile, IProviderUserOptions, getProviderDescription, filterMatches, removeLocal, setLocal, CONNECT_EVENT, ERROR_EVENT, connectors, injected, providers } from 'web3modal'
 
-export class ProviderController {
-  public cachedProvider: string = "";
+export class RLoginProviderController {
+  public cachedProvider: string = '';
   public shouldCacheProvider: boolean = false;
   public disableInjectedProvider: boolean = false;
 
@@ -32,162 +9,172 @@ export class ProviderController {
   private injectedProvider: IProviderInfo | null = null;
   private providers: IProviderDisplayWithConnector[] = [];
   private providerOptions: IProviderOptions;
-  private network: string = "";
+  private network: string = '';
 
-  constructor(opts: IProviderControllerOptions) {
-    this.cachedProvider = getLocal(CACHED_PROVIDER_KEY) || "";
+  constructor (opts: IProviderControllerOptions) {
+    this.cachedProvider = getLocal(CACHED_PROVIDER_KEY) || ''
 
-    this.disableInjectedProvider = opts.disableInjectedProvider;
-    this.shouldCacheProvider = opts.cacheProvider;
-    this.providerOptions = opts.providerOptions;
-    this.network = opts.network;
+    this.disableInjectedProvider = opts.disableInjectedProvider
+    this.shouldCacheProvider = opts.cacheProvider
+    this.providerOptions = opts.providerOptions
+    this.network = opts.network
 
-    this.injectedProvider = getInjectedProvider();
+    this.injectedProvider = getInjectedProvider()
+
+    type ListI = {
+      connectors: any,
+      injected: any,
+      providers: any
+    }
+
+    const list: ListI = { connectors, injected, providers }
 
     this.providers = Object.keys(list.connectors).map((id: string) => {
-      let providerInfo: IProviderInfo;
+      let providerInfo: IProviderInfo
       if (id === INJECTED_PROVIDER_ID) {
-        providerInfo = this.injectedProvider || list.providers.FALLBACK;
+        providerInfo = this.injectedProvider || list.providers.FALLBACK
       } else {
-        providerInfo = getProviderInfoById(id);
+        providerInfo = getProviderInfoById(id)
       }
+
       // parse custom display options
       if (this.providerOptions[id]) {
-        const options = this.providerOptions[id];
-        if (typeof options.display !== "undefined") {
+        const options = this.providerOptions[id]
+        if (typeof options.display !== 'undefined') {
           providerInfo = {
             ...providerInfo,
             ...this.providerOptions[id].display
-          };
+          }
         }
       }
+
       return {
         ...providerInfo,
         connector: list.connectors[id],
         package: providerInfo.package
-      };
-    });
+      }
+    })
     // parse custom providers
     Object.keys(this.providerOptions)
-      .filter(key => key.startsWith("custom-"))
+      .filter(key => key.startsWith('custom-'))
       .map(id => {
         if (id && this.providerOptions[id]) {
-          const options = this.providerOptions[id];
+          const options = this.providerOptions[id]
           if (
-            typeof options.display !== "undefined" &&
-            typeof options.connector !== "undefined"
+            typeof options.display !== 'undefined' &&
+            typeof options.connector !== 'undefined'
           ) {
             this.providers.push({
               ...list.providers.FALLBACK,
               id,
               ...options.display,
               connector: options.connector
-            });
+            })
           }
         }
-      });
+      })
   }
 
-  public shouldDisplayProvider(id: string) {
-    const provider = this.getProvider(id);
-    if (typeof provider !== "undefined") {
-      const providerPackageOptions = this.providerOptions[id];
+  public shouldDisplayProvider (id: string) {
+    const provider = this.getProvider(id)
+    if (typeof provider !== 'undefined') {
+      const providerPackageOptions = this.providerOptions[id]
       if (providerPackageOptions) {
-        const isProvided = !!providerPackageOptions.package;
+        const isProvided = !!providerPackageOptions.package
         if (isProvided) {
           const requiredOptions = provider.package
             ? provider.package.required
-            : undefined;
+            : undefined
           if (requiredOptions && requiredOptions.length) {
-            const providedOptions = providerPackageOptions.options;
+            const providedOptions = providerPackageOptions.options
             if (providedOptions && Object.keys(providedOptions).length) {
               const matches = findMatchingRequiredOptions(
                 requiredOptions,
                 providedOptions
-              );
+              )
               if (requiredOptions.length === matches.length) {
-                return true;
+                return true
               }
             }
           } else {
-            return true;
+            return true
           }
         }
       }
     }
-    return false;
+    return false
   }
 
   public getUserOptions = () => {
-    const mobile = isMobile();
+    const mobile = isMobile()
 
-    const defaultProviderList = this.providers.map(({ id }) => id);
+    const defaultProviderList = this.providers.map(({ id }) => id)
 
     const displayInjected =
-      !!this.injectedProvider && !this.disableInjectedProvider;
-    const onlyInjected = displayInjected && mobile;
+      !!this.injectedProvider && !this.disableInjectedProvider
+    const onlyInjected = displayInjected && mobile
 
-    const providerList = [];
+    const providerList = []
 
     if (onlyInjected) {
-      providerList.push(INJECTED_PROVIDER_ID);
+      providerList.push(INJECTED_PROVIDER_ID)
     } else {
       if (displayInjected) {
-        providerList.push(INJECTED_PROVIDER_ID);
+        providerList.push(INJECTED_PROVIDER_ID)
       }
 
       defaultProviderList.forEach((id: string) => {
         if (id !== INJECTED_PROVIDER_ID) {
-          const result = this.shouldDisplayProvider(id);
+          const result = this.shouldDisplayProvider(id)
           if (result) {
-            providerList.push(id);
+            providerList.push(id)
           }
         }
-      });
+      })
     }
 
-    const userOptions: IProviderUserOptions[] = [];
+    const userOptions: IProviderUserOptions[] = []
 
     providerList.forEach((id: string) => {
-      let provider = this.getProvider(id);
-      if (typeof provider !== "undefined") {
-        const { id, name, logo, connector } = provider;
+      const provider = this.getProvider(id)
+      if (typeof provider !== 'undefined') {
+        const { id, name, logo, connector } = provider
         userOptions.push({
           name,
           logo,
           description: getProviderDescription(provider),
           onClick: () => this.connectTo(id, connector)
-        });
+        })
       }
-    });
+    })
 
-    return userOptions;
+    return userOptions
   };
 
-  public getProvider(id: string) {
+  public getProvider (id: string) {
     return filterMatches<IProviderDisplayWithConnector>(
       this.providers,
-      x => x.id === id,
+      (x: { id: string; }) => x.id === id,
       undefined
-    );
+    )
   }
 
-  public getProviderOption(id: string, key: string) {
+  public getProviderOption (id: string, key: 'package' | 'options') {
     return this.providerOptions &&
       this.providerOptions[id] &&
       this.providerOptions[id][key]
       ? this.providerOptions[id][key]
-      : {};
+      : {}
   }
 
-  public clearCachedProvider() {
-    this.cachedProvider = "";
-    removeLocal(CACHED_PROVIDER_KEY);
+  public clearCachedProvider () {
+    this.cachedProvider = ''
+    removeLocal(CACHED_PROVIDER_KEY)
   }
 
-  public setCachedProvider(id: string) {
-    this.cachedProvider = id;
-    setLocal(CACHED_PROVIDER_KEY, id);
+  public setCachedProvider (id: string) {
+    this.cachedProvider = id
+    setLocal(CACHED_PROVIDER_KEY, id)
   }
 
   public connectTo = async (
@@ -195,43 +182,43 @@ export class ProviderController {
     connector: (providerPackage: any, opts: any) => Promise<any>
   ) => {
     try {
-      const providerPackage = this.getProviderOption(id, "package");
-      const providerOptions = this.getProviderOption(id, "options");
-      const opts = { network: this.network || undefined, ...providerOptions };
-      const provider = await connector(providerPackage, opts);
-      this.eventController.trigger(CONNECT_EVENT, provider);
+      const providerPackage = this.getProviderOption(id, 'package')
+      const providerOptions = this.getProviderOption(id, 'options')
+      const opts = { network: this.network || undefined, ...providerOptions }
+      const provider = await connector(providerPackage, opts)
+      this.eventController.trigger(CONNECT_EVENT, provider)
       if (this.shouldCacheProvider && this.cachedProvider !== id) {
-        this.setCachedProvider(id);
+        this.setCachedProvider(id)
       }
     } catch (error) {
-      this.eventController.trigger(ERROR_EVENT);
+      this.eventController.trigger(ERROR_EVENT)
     }
   };
 
-  public async connectToCachedProvider() {
-    const provider = this.getProvider(this.cachedProvider);
-    if (typeof provider !== "undefined") {
-      await this.connectTo(provider.id, provider.connector);
+  public async connectToCachedProvider () {
+    const provider = this.getProvider(this.cachedProvider)
+    if (typeof provider !== 'undefined') {
+      await this.connectTo(provider.id, provider.connector)
     }
   }
 
-  public on(event: string, callback: (result: any) => void): () => void {
+  public on (event: string, callback: (result: any) => void): () => void {
     this.eventController.on({
       event,
       callback
-    });
+    })
 
     return () =>
       this.eventController.off({
         event,
         callback
-      });
+      })
   }
 
-  public off(event: string, callback?: (result: any) => void): void {
+  public off (event: string, callback?: (result: any) => void): void {
     this.eventController.off({
       event,
       callback
-    });
+    })
   }
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -35,7 +35,8 @@ const resources = {
       'Wallet address': 'Wallet address',
       Network: 'Network',
       'Do not show again': 'Don\'t show again',
-      'Connected wallet': 'Connected wallet'
+      'Connected wallet': 'Connected wallet',
+      'Choose Network': 'Choose Network'
     }
   },
   es: {

--- a/src/ui/shared/SelectDropdown.tsx
+++ b/src/ui/shared/SelectDropdown.tsx
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-use-before-define
+import styled from 'styled-components'
+
+const Select = styled.select`
+  padding: 10px 25px 10px 10px;
+  border-radius: 5px;
+
+  &:focus {
+    outline: none;
+  }
+`
+
+export default Select

--- a/src/ui/shared/SelectDropdown.tsx
+++ b/src/ui/shared/SelectDropdown.tsx
@@ -1,9 +1,13 @@
 // eslint-disable-next-line no-use-before-define
 import styled from 'styled-components'
+import { typeShared } from './Typography'
 
 const Select = styled.select`
+  ${typeShared}
   padding: 10px 25px 10px 10px;
   border-radius: 5px;
+  background: ${props => props.theme.modalBackground};
+  color: ${props => props.theme.p};
 
   &:focus {
     outline: none;

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -1,0 +1,38 @@
+// eslint-disable-next-line no-use-before-define
+import React from 'react'
+import { mount } from 'enzyme'
+import ChooseNetworkComponent from './ChooseNetworkComponent'
+
+describe('Component: ChooseNetworkComponent', () => {
+  const sharedProps = {
+    rpcUrls: {
+      1: 'http://1',
+      30: 'http://30',
+      31: 'http://31'
+    },
+    chooseNetwork: jest.fn()
+  }
+
+  it('renders the component', () => {
+    const wrapper = mount(<ChooseNetworkComponent {...sharedProps} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders the select options', () => {
+    const wrapper = mount(<ChooseNetworkComponent {...sharedProps} />)
+    expect(wrapper.find('select').children()).toHaveLength(3)
+    expect(wrapper.find('option').at(0).props().value).toBe('1')
+    expect(wrapper.find('option').at(0).text()).toBe('Network 1')
+  })
+
+  it('handles the click method', () => {
+    const localProps = {
+      ...sharedProps,
+      chooseNetwork: jest.fn()
+    }
+    const wrapper = mount(<ChooseNetworkComponent {...localProps} />)
+
+    wrapper.find('button').simulate('click')
+    expect(localProps.chooseNetwork).toBeCalledWith(1, 'http://1')
+  })
+})

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -33,6 +33,6 @@ describe('Component: ChooseNetworkComponent', () => {
     const wrapper = mount(<ChooseNetworkComponent {...localProps} />)
 
     wrapper.find('button').simulate('click')
-    expect(localProps.chooseNetwork).toBeCalledWith(1, 'http://1')
+    expect(localProps.chooseNetwork).toBeCalledWith({ chainId: 1, rpcUrl: 'http://1' })
   })
 })

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -22,7 +22,7 @@ describe('Component: ChooseNetworkComponent', () => {
     const wrapper = mount(<ChooseNetworkComponent {...sharedProps} />)
     expect(wrapper.find('select').children()).toHaveLength(3)
     expect(wrapper.find('option').at(0).props().value).toBe('1')
-    expect(wrapper.find('option').at(0).text()).toBe('Network 1')
+    expect(wrapper.find('option').at(0).text()).toBe('Ethereum Mainnet')
   })
 
   it('handles the click method', () => {

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -1,8 +1,11 @@
 // eslint-disable-next-line no-use-before-define
 import React, { useState } from 'react'
+import { Trans } from 'react-i18next'
+
 import { Header2 } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
 import Select from '../../ui/shared/SelectDropdown'
+import { getChainName } from '../../adapters'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
@@ -23,11 +26,11 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
 
   return (
     <div>
-      <Header2>Choose Network</Header2>
+      <Header2><Trans>Choose Network</Trans></Header2>
       <p>
         <Select value={selectedChainId} onChange={evt => setSelectedChainId(evt.target.value)}>
           {Object.keys(rpcUrls).map((chainId: string) =>
-            <option key={chainId} value={chainId}>{`Network ${chainId}`}</option>
+            <option key={chainId} value={chainId}>{getChainName(parseInt(chainId))}</option>
           )}
         </Select>
       </p>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -1,0 +1,41 @@
+// eslint-disable-next-line no-use-before-define
+import React, { useState } from 'react'
+import { Header2 } from '../../ui/shared/Typography'
+import { Button } from '../../ui/shared/Button'
+import Select from '../../ui/shared/SelectDropdown'
+
+interface Interface {
+  rpcUrls?: {[key: string]: string}
+  chooseNetwork: (chainId: number, url: string) => void
+}
+
+const ChooseNetworkComponent: React.FC<Interface> = ({
+  rpcUrls,
+  chooseNetwork
+}) => {
+  if (!rpcUrls) {
+    return <></>
+  }
+  const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
+
+  const handleSelect = () =>
+    chooseNetwork(parseInt(selectedChainId), rpcUrls[selectedChainId])
+
+  return (
+    <div>
+      <Header2>Choose Network</Header2>
+      <p>
+        <Select value={selectedChainId} onChange={evt => setSelectedChainId(evt.target.value)}>
+          {Object.keys(rpcUrls).map((chainId: string) =>
+            <option key={chainId} value={chainId}>{`Network ${chainId}`}</option>
+          )}
+        </Select>
+      </p>
+      <p>
+        <Button onClick={handleSelect}>Choose</Button>
+      </p>
+    </div>
+  )
+}
+
+export default ChooseNetworkComponent

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -6,7 +6,7 @@ import Select from '../../ui/shared/SelectDropdown'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
-  chooseNetwork: (chainId: number, url: string) => void
+  chooseNetwork: (network: { chainId: number, rpcUrl: string }) => void
 }
 
 const ChooseNetworkComponent: React.FC<Interface> = ({
@@ -19,7 +19,7 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
 
   const handleSelect = () =>
-    chooseNetwork(parseInt(selectedChainId), rpcUrls[selectedChainId])
+    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId] })
 
   return (
     <div>

--- a/src/ux/step1/WalletProviders.test.tsx
+++ b/src/ux/step1/WalletProviders.test.tsx
@@ -13,7 +13,7 @@ describe('Component: WalletProviders', () => {
 
   const props = {
     userProviders: providers,
-    setLoading: jest.fn(),
+    connectToWallet: jest.fn(),
     changeLanguage: jest.fn(),
     availableLanguages: [{ code: 'en', name: 'English' }, { code: 'es', name: 'Spanish' }],
     selectedLanguageCode: 'en',

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -13,7 +13,7 @@ import { EDGE, TREZOR, LEDGER, DCENT } from './extraProviders'
 
 interface IWalletProvidersProps {
   userProviders: IProviderUserOptions[]
-  setLoading: (providerUserOption: IProviderUserOptions) => void
+  connectToWallet: (provider: IProviderUserOptions) => void
   changeLanguage: (event: any) => void
   changeTheme: (theme: themesOptions) => void
   availableLanguages: { code:string, name:string } []
@@ -90,7 +90,7 @@ export const userProvidersByName = (userProviders: IProviderUserOptions[]) => {
   return providersByName
 }
 
-export const WalletProviders = ({ userProviders, setLoading, changeLanguage, changeTheme, availableLanguages, selectedLanguageCode, selectedTheme }: IWalletProvidersProps) => {
+export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage, changeTheme, availableLanguages, selectedLanguageCode, selectedTheme }: IWalletProvidersProps) => {
   // the providers that are hardcoded into the layout below
   const hardCodedProviderNames = [
     providers.METAMASK.name, providers.NIFTY.name, providers.LIQUALITY.name,
@@ -105,10 +105,7 @@ export const WalletProviders = ({ userProviders, setLoading, changeLanguage, cha
     !hardCodedProviderNames.includes(providerName) ? providerName : null)
 
   // handle connect
-  const handleConnect = (provider: IProviderUserOptions) => {
-    setLoading(provider)
-    provider.onClick()
-  }
+  const handleConnect = (provider: IProviderUserOptions) => connectToWallet(provider)
 
   return <>
     <Header2>


### PR DESCRIPTION
Allows the user to choose the network when selecting hardware wallets.

![Screen Shot 2021-09-13 at 4 08 41 PM](https://user-images.githubusercontent.com/766679/133089250-c3c97465-a8a1-4ceb-969c-323caebefb2f.png)

See detailed commit messages for full details.

## provider controller

To accomplish this the provider controller has been taken from web3modal (src/controllers/providers.ts). The majority of this file has stayed the same, the following things were added or changed:

* `onClick` method accepts an optional parameter with RPCURL and ChainId [here](https://github.com/rsksmart/rLogin/blob/choose-network/src/controllers/providers.ts#L146). This is how the whole thing works.
* `connectTo` method also accepts the optional parameter. [See here](https://github.com/rsksmart/rLogin/blob/choose-network/src/controllers/providers.ts#L180)

In the future, this file could be used to solve #106, and 
 https://github.com/Web3Modal/web3modal/pull/300