### PR TITLE
Handle provider error

### DIFF
--- a/cypress/integration/1-modal/rlogin-retry-provider_spec.js
+++ b/cypress/integration/1-modal/rlogin-retry-provider_spec.js
@@ -16,17 +16,19 @@ describe('modal - chose metamask fails, then walletconnect works', () => {
     })
   })
 
-  it('Try to open Metamask but fails', () => { // no error here until web3modal fixes the error return for connect
+  it('Try to open Metamask but fails', () => {
     cy.visit('/')
     cy.contains('login with rLogin').click()
     cy.contains('MetaMask').click()
-    cy.get('.rlogin-modal-lightbox').should('be.not.visible')
+    cy.get('.rlogin-header2').should('have.text', 'Could not connect to MetaMask')
+    cy.get('.rlogin-modal-close-button').click()
   })
 
-  it('retry to open Metamask but fails', () => { // no error here until web3modal fixes the error return for connect
+  it('retry to open Metamask but fails', () => {
     cy.contains('login with rLogin').click()
     cy.contains('MetaMask').click()
-    cy.get('.rlogin-modal-lightbox').should('be.not.visible')
+    cy.get('.rlogin-header2').should('have.text', 'Could not connect to MetaMask')
+    cy.get('.rlogin-modal-close-button').click()
   })
 
   it('shows a QR code for WalletConnect', () => { // try with WalletConnect should work

--- a/cypress/integration/2-sample-app/providerError_spec.js
+++ b/cypress/integration/2-sample-app/providerError_spec.js
@@ -13,7 +13,6 @@ describe('Web3 Provider throws an error when connecting', () => {
     })
 
     // overwrite the enable method to throw an error:
-    // console.log(provider)
     provider.request = (_props) => Promise.reject(new Error('Not today'))
 
     cy.on('window:before:load', (win) => {
@@ -27,6 +26,6 @@ describe('Web3 Provider throws an error when connecting', () => {
     cy.contains('MetaMask').click()
 
     cy.get('.rlogin-header2').should('have.text', 'Could not connect to MetaMask')
-    cy.get('.rlogin-paragraph').should('have.text', 'Not today')
+    cy.get('.rlogin-paragraph').should('have.text', 'User Rejected')
   })
 })

--- a/cypress/integration/2-sample-app/providerError_spec.js
+++ b/cypress/integration/2-sample-app/providerError_spec.js
@@ -1,0 +1,32 @@
+import currentProvider from '@rsksmart/mock-web3-provider'
+
+describe('Web3 Provider throws an error when connecting', () => {
+  const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
+  const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
+
+  beforeEach(() => {
+    const provider = currentProvider({
+      address,
+      privateKey,
+      chainId: 31,
+      debug: true
+    })
+
+    // overwrite the enable method to throw an error:
+    // console.log(provider)
+    provider.request = (_props) => Promise.reject(new Error('Not today'))
+
+    cy.on('window:before:load', (win) => {
+      win.ethereum = provider
+    })
+  })
+
+  it('shows an error when the provider throws', () => {
+    cy.visit('/')
+    cy.get('#login').click()
+    cy.contains('MetaMask').click()
+
+    cy.get('.rlogin-header2').should('have.text', 'Could not connect to MetaMask')
+    cy.get('.rlogin-paragraph').should('have.text', 'Not today')
+  })
+})

--- a/cypress/integration/2-sample-app/providerError_spec.js
+++ b/cypress/integration/2-sample-app/providerError_spec.js
@@ -28,4 +28,14 @@ describe('Web3 Provider throws an error when connecting', () => {
     cy.get('.rlogin-header2').should('have.text', 'Could not connect to MetaMask')
     cy.get('.rlogin-paragraph').should('have.text', 'User Rejected')
   })
+
+  it('starts over', () => {
+    cy.visit('/')
+    cy.get('#login').click()
+    cy.contains('MetaMask').click()
+    cy.get('.rlogin-header2').should('have.text', 'Could not connect to MetaMask')
+
+    cy.contains('Start Over').click()
+    cy.get('.rlogin-header2').should('have.text', 'Connect your wallet')
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rlogin",
-      "version": "1.2.0-beta.2",
+      "version": "1.2.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -28,6 +28,7 @@ import { ThemeType, themesOptions } from './theme'
 import { ConfirmInformation } from './ux/confirmInformation/ConfirmInformation'
 import ChooseNetworkComponent from './ux/chooseNetwork/ChooseNetworkComponent'
 import TutorialComponent from './ux/tutorial/TutorialComponent'
+import { Button } from './ui/shared/Button'
 
 // copy-pasted and adapted
 // https://github.com/Web3Modal/web3modal/blob/4b31a6bdf5a4f81bf20de38c45c67576c3249bfc/src/components/Modal.tsx
@@ -82,6 +83,7 @@ type Step = 'Step1' | 'Step2' | 'ConfirmInformation' | 'error' | 'wrongNetwork' 
 interface ErrorDetails {
   title: string
   description?: string
+  footerCta?: React.ReactNode
 }
 
 interface IAvailableLanguage {
@@ -305,7 +307,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
            currentStep: 'error',
            errorReason: {
              title: `Could not connect to ${providerName}`,
-             description: (err instanceof Error) ? err.message : err.toString()
+             description: (err instanceof Error) ? err.message : err.toString(),
+             footerCta: <Button onClick={() => this.setState({ ...INITIAL_STATE, show: true })}>Start Over</Button>
            }
          }))
    }
@@ -498,7 +501,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {currentStep === 'Step1' && <WalletProviders userProviders={userProviders} connectToWallet={this.preConnectChecklist} changeLanguage={this.changeLanguage} availableLanguages={this.availableLanguages} selectedLanguageCode={this.selectedLanguageCode} changeTheme={this.changeTheme} selectedTheme={this.selectedTheme} />}
         {currentStep === 'Step2' && <SelectiveDisclosure sdr={sdr!} backendUrl={backendUrl!} fetchSelectiveDisclosureRequest={this.fetchSelectiveDisclosureRequest} onConfirm={this.onConfirmSelectiveDisclosure} providerName={selectedProviderUserOption?.name} />}
         {currentStep === 'ConfirmInformation' && <ConfirmInformation chainId={chainId} address={address} provider={provider} providerUserOption={selectedProviderUserOption!} sd={sd} onConfirm={this.onConfirmAuth} onCancel={handleClose} providerName={selectedProviderUserOption?.name} />}
-        {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description}/>}
+        {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {currentStep === 'wrongNetwork' && <WrongNetworkComponent supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
         {currentStep === 'chooseNetwork' && <ChooseNetworkComponent rpcUrls={rpcUrls} chooseNetwork={({ chainId, rpcUrl }) => this.chooseNetwork({ rpcUrl, chainId })} />}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -119,11 +119,11 @@ const INITIAL_STATE: IModalState = {
 /**
  * IProviderUserOptions with added onClick variable
  */
-interface RLoginIProviderUserOptions {
+export interface RLoginIProviderUserOptions extends IProviderUserOptions {
   name: string;
   logo: string;
   description: string;
-  onClick: (optionalOpts?: { chainId: number, rpcUrl: string }) => Promise<void>; // adds optional options
+  onClick: (optionalOpts?: { chainId: number, rpcUrl: string }) => Promise<any>; // adds optional options
 }
 
 export class Core extends React.Component<IModalProps, IModalState> {
@@ -292,13 +292,22 @@ export class Core extends React.Component<IModalProps, IModalState> {
    private connectToWallet () {
      const { provider, chosenNetwork } = this.state
      const providerName = provider.name || 'Provider'
-     provider.onClick(chosenNetwork)
 
-     this.setState({
-       currentStep: 'loading',
-       loadingReason: `Connecting to ${providerName}`,
-       selectedProviderUserOption: provider
-     })
+     provider.onClick(chosenNetwork)
+       .then(() =>
+         this.setState({
+           currentStep: 'loading',
+           loadingReason: `Connecting to ${providerName}`,
+           selectedProviderUserOption: provider
+         }))
+       .catch((err: any) =>
+         this.setState({
+           currentStep: 'error',
+           errorReason: {
+             title: `Could not connect to ${providerName}`,
+             description: (err instanceof Error) ? err.message : err.toString()
+           }
+         }))
    }
 
    /** Step 1 Provider Answered

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -1,4 +1,4 @@
-import { EventController, IProviderInfo, IProviderDisplayWithConnector, IProviderOptions, IProviderControllerOptions, getLocal, CACHED_PROVIDER_KEY, getInjectedProvider, INJECTED_PROVIDER_ID, getProviderInfoById, findMatchingRequiredOptions, isMobile, IProviderUserOptions, getProviderDescription, filterMatches, removeLocal, setLocal, CONNECT_EVENT, ERROR_EVENT, connectors, injected, providers } from 'web3modal'
+import { EventController, IProviderInfo, IProviderDisplayWithConnector, IProviderOptions, IProviderControllerOptions, getLocal, CACHED_PROVIDER_KEY, getInjectedProvider, INJECTED_PROVIDER_ID, getProviderInfoById, findMatchingRequiredOptions, isMobile, getProviderDescription, filterMatches, removeLocal, setLocal, CONNECT_EVENT, connectors, injected, providers } from 'web3modal'
 
 import { RLoginIProviderUserOptions } from '../Core'
 

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -1,5 +1,7 @@
 import { EventController, IProviderInfo, IProviderDisplayWithConnector, IProviderOptions, IProviderControllerOptions, getLocal, CACHED_PROVIDER_KEY, getInjectedProvider, INJECTED_PROVIDER_ID, getProviderInfoById, findMatchingRequiredOptions, isMobile, IProviderUserOptions, getProviderDescription, filterMatches, removeLocal, setLocal, CONNECT_EVENT, ERROR_EVENT, connectors, injected, providers } from 'web3modal'
 
+import { RLoginIProviderUserOptions } from '../Core'
+
 export class RLoginProviderController {
   public cachedProvider: string = '';
   public shouldCacheProvider: boolean = false;
@@ -133,7 +135,7 @@ export class RLoginProviderController {
       })
     }
 
-    const userOptions: IProviderUserOptions[] = []
+    const userOptions: RLoginIProviderUserOptions[] = []
 
     providerList.forEach((id: string) => {
       const provider = this.getProvider(id)
@@ -177,27 +179,30 @@ export class RLoginProviderController {
     setLocal(CACHED_PROVIDER_KEY, id)
   }
 
-  public connectTo = async (
+  public connectTo = (
     id: string,
     connector: (providerPackage: any, opts: any) => Promise<any>,
     optionalOpts?: { chainId?: number, rpcUrl?: string }
   ) => {
-    try {
-      const providerPackage = this.getProviderOption(id, 'package')
-      const providerOptions = {
-        ...this.getProviderOption(id, 'options'),
-        ...optionalOpts
-      }
-
-      const opts = { network: this.network || undefined, ...providerOptions }
-      const provider = await connector(providerPackage, opts)
-      this.eventController.trigger(CONNECT_EVENT, provider)
-      if (this.shouldCacheProvider && this.cachedProvider !== id) {
-        this.setCachedProvider(id)
-      }
-    } catch (error) {
-      this.eventController.trigger(ERROR_EVENT)
+    const providerPackage = this.getProviderOption(id, 'package')
+    const providerOptions = {
+      ...this.getProviderOption(id, 'options'),
+      ...optionalOpts
     }
+
+    const opts = { network: this.network || undefined, ...providerOptions }
+
+    return new Promise((resolve, reject) => {
+      connector(providerPackage, opts)
+        .then((provider: any) => {
+          this.eventController.trigger(CONNECT_EVENT, provider)
+          if (this.shouldCacheProvider && this.cachedProvider !== id) {
+            this.setCachedProvider(id)
+          }
+          resolve(true)
+        })
+        .catch((err: any) => reject(err))
+    })
   };
 
   public async connectToCachedProvider () {

--- a/src/ui/shared/ErrorMessage.test.tsx
+++ b/src/ui/shared/ErrorMessage.test.tsx
@@ -13,4 +13,11 @@ describe('Component: Error Message', () => {
     expect(wrapper.find('h2').text()).toBe('A title')
     expect(wrapper.find('p').text()).toBe('Error description')
   })
+
+  it('handles call to action', () => {
+    const footer = <p>Click me!</p>
+    const wrapper = mount(<ErrorMessage title="A title" description="Error description" footerCta={footer} />)
+
+    expect(wrapper.find('.footer').text()).toBe('Click me!')
+  })
 })

--- a/src/ui/shared/ErrorMessage.tsx
+++ b/src/ui/shared/ErrorMessage.tsx
@@ -8,6 +8,7 @@ interface ErrorMessageInterface {
   className?: string;
   title?: string;
   description?: string;
+  footerCta?: React.ReactNode;
 }
 
 const ErrorHeading = styled.h2`
@@ -18,10 +19,11 @@ const ErrorHeading = styled.h2`
 
 const forceString = (text: any) => typeof text === 'string' ? text : (text as any).toString()
 
-export const ErrorMessage: React.FC<ErrorMessageInterface> = ({ className, title, description }) => (
+export const ErrorMessage: React.FC<ErrorMessageInterface> = ({ className, title, description, footerCta }) => (
   <div className={className ? `${ERROR_MESSAGE_WRAPPER} ${className}` : ERROR_MESSAGE_WRAPPER}>
     <ErrorCircle />
     {title && <ErrorHeading className={HEADER2_CLASS}>{forceString(title)}</ErrorHeading>}
     {description && <Paragraph>{forceString(description)}</Paragraph>}
+    {footerCta && <div className="footer">{footerCta}</div>}
   </div>
 )


### PR DESCRIPTION
Return the error from the provider to the UI so it can be displayed on the screen.  This is mostly for the new hardware wallets but will also work for the injected provider.

Resolves #106 

### hardware wallets

Ledger, trying to connect to RSK testnet using the RSK Ledger app. The error is set [from the provider](https://github.com/rsksmart/rLogin-providers/blob/develop/packages/rlogin-ledger-provider/src/LedgerProvider.ts#L52).

![Screenshot 2021-09-23 at 1 31 31 PM](https://user-images.githubusercontent.com/766679/134495342-d3a81eb5-9a26-49ce-9866-8f825416689e.png)

### injected provider

The injected provider will always throw "User Rejected." because of [this line in web3modal](https://github.com/Web3Modal/web3modal/blob/master/src/providers/connectors/injected.ts#L8). This is pulled by a few files before it gets to the provider controller. I don't know if it makes sense to fix this in this pr.

![Screenshot 2021-09-23 at 1 56 45 PM](https://user-images.githubusercontent.com/766679/134495532-f88e0506-b075-4ef6-8824-f8be956d417d.png)
 
