### PR TITLE
Fix rbutton

### DIFF
--- a/src/components/shared/RLoginButton.test.tsx
+++ b/src/components/shared/RLoginButton.test.tsx
@@ -3,9 +3,23 @@ import { mount } from 'enzyme'
 import { RLoginButton } from './RLoginButton'
 
 describe('Component: RLoginButton', () => {
-  const wrapper = mount(<RLoginButton onClick={jest.fn()}>Hello World!</RLoginButton>)
-  it('renders the component', () => {
+  it('renders the component with text', () => {
+    const wrapper = mount(<RLoginButton onClick={jest.fn()}>Hello World!</RLoginButton>)
     expect(wrapper).toBeDefined()
     expect(wrapper.text()).toBe('Hello World!')
+  })
+
+  it('handles click method', () => {
+    const onClick = jest.fn()
+    const wrapper = mount(<RLoginButton onClick={onClick}>Hello World!</RLoginButton>)
+    wrapper.find('button').simulate('click')
+    expect(onClick).toBeCalledTimes(1)
+  })
+
+  it('does not click when it is disabled', () => {
+    const onClick = jest.fn()
+    const wrapper = mount(<RLoginButton disabled={true} onClick={onClick}>Hello World!</RLoginButton>)
+    wrapper.find('button').simulate('click')
+    expect(onClick).toBeCalledTimes(0)
   })
 })

--- a/src/components/shared/RLoginButton.test.tsx
+++ b/src/components/shared/RLoginButton.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { RLoginButton } from './RLoginButton'
+
+describe('Component: RLoginButton', () => {
+  const wrapper = mount(<RLoginButton onclick={jest.fn()}>Hello World!</RLoginButton>)
+  it('renders the component', () => {
+    expect(wrapper).toBeDefined()
+    expect(wrapper.text()).toBe('Hello World!')
+  })
+})

--- a/src/components/shared/RLoginButton.test.tsx
+++ b/src/components/shared/RLoginButton.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import { RLoginButton } from './RLoginButton'
 
 describe('Component: RLoginButton', () => {
-  const wrapper = mount(<RLoginButton onclick={jest.fn()}>Hello World!</RLoginButton>)
+  const wrapper = mount(<RLoginButton onClick={jest.fn()}>Hello World!</RLoginButton>)
   it('renders the component', () => {
     expect(wrapper).toBeDefined()
     expect(wrapper.text()).toBe('Hello World!')

--- a/src/components/shared/RLoginButton.tsx
+++ b/src/components/shared/RLoginButton.tsx
@@ -6,20 +6,21 @@ interface RLoginButtonInterface {
   disabled?: boolean
 }
 
+const ButtonWrapper = styled.button<{ disabled: boolean }>`
+  display: 'inline-block';
+  margin: '10px';
+  padding: '10px 50px';
+  border: 'none';
+  border-radius: '5px';
+  box-shadow: '0px 4px 10px rgba(0,0,0,0.1)';
+  font-size: '18px';
+  line-height: '100%';
+  cursor: ${(disabled) => disabled ? 'auto' : 'pointer'};
+  backgroundColor: '#008FF7';
+  color: '#FFFFFF';
+`
+
 export const RLoginButton: React.FC<RLoginButtonInterface> = ({ children, disabled, onClick }) => {
-  const ButtonWrapper = styled.button`
-    display: 'inline-block';
-    margin: '10px';
-    padding: '10px 50px';
-    border: 'none';
-    border-radius: '5px';
-    box-shadow: '0px 4px 10px rgba(0,0,0,0.1)';
-    font-size: '18px';
-    line-height: '100%';
-    cursor: ${() => disabled ? 'auto' : 'pointer'};
-    backgroundColor: '#008FF7';
-    color: '#FFFFFF';
-  `
   return (
     <ButtonWrapper
       onClick={onClick}

--- a/src/components/shared/RLoginButton.tsx
+++ b/src/components/shared/RLoginButton.tsx
@@ -1,31 +1,34 @@
 import React, { ReactNode } from 'react'
-import styled from 'styled-components'
+
 interface RLoginButtonInterface {
   children: ReactNode
   onClick?: () => void
   disabled?: boolean
 }
 
-const ButtonWrapper = styled.button<{ disabled: boolean }>`
-  display: 'inline-block';
-  margin: '10px';
-  padding: '10px 50px';
-  border: 'none';
-  border-radius: '5px';
-  box-shadow: '0px 4px 10px rgba(0,0,0,0.1)';
-  font-size: '18px';
-  line-height: '100%';
-  cursor: ${(disabled) => disabled ? 'auto' : 'pointer'};
-  backgroundColor: '#008FF7';
-  color: '#FFFFFF';
-`
-
-export const RLoginButton: React.FC<RLoginButtonInterface> = ({ children, disabled, onClick }) => {
-  return (
-    <ButtonWrapper
-      onClick={onClick}
-      className="rlogin-button"
-      disabled={disabled || false}
-    >{children}</ButtonWrapper>
-  )
+const buttonStyles = {
+  display: 'inline-block',
+  margin: '10px',
+  padding: '10px 50px',
+  border: 'none',
+  borderRadius: '5px',
+  boxShadow: '0px 4px 10px rgba(0,0,0,0.1)',
+  fontSize: '18px',
+  lineHeight: '100%',
+  backgroundColor: '#008FF7',
+  color: '#FFF',
+  cursor: 'pointer'
 }
+
+export const RLoginButton: React.FC<RLoginButtonInterface> = ({ children, disabled, onClick }) => (
+  <button
+    onClick={onClick}
+    className="rlogin-button"
+    disabled={disabled || false}
+    style={{
+      ...buttonStyles,
+      cursor: disabled ? 'auto' : 'pointer',
+      opacity: disabled ? 0.5 : 1
+    }}
+  >{children}</button>
+)

--- a/src/components/shared/RLoginButton.tsx
+++ b/src/components/shared/RLoginButton.tsx
@@ -17,8 +17,8 @@ export const RLoginButton: React.FC<RLoginButtonInterface> = ({ children, disabl
     font-size: '18px';
     line-height: '100%';
     cursor: ${() => disabled ? 'auto' : 'pointer'};
-    background-color: ${props => disabled ? props.theme.disabledBackground : props.theme.primaryBackground};
-    color: ${props => disabled ? props.theme.disabledText : props.theme.primaryText};
+    backgroundColor: '#008FF7';
+    color: '#FFFFFF';
   `
   return (
     <ButtonWrapper


### PR DESCRIPTION
There were two issues here which I could not solve. 

1. the styled components were throwing an error and had something to do with versions, and outputting. I tried updating the peerDependecies but it still had an issue.
2. the themeProvider looked like it was expected since the colors were based on the theme.

This is only happening when we exported this single component and not with the rLogin modal. This component is also tiny and does not need to complexity of Styled components... so I converted it to plain old JavaScript CSS. 

What it looks like imported into a fresh cra:

![Screenshot 2021-09-23 at 3 46 36 PM](https://user-images.githubusercontent.com/766679/134509062-bce22c06-21fe-45ec-8b48-82dcee3966de.png)
 
Resolves #144 