### PR TITLE
Refactor disconnect and closeModal methods

### DIFF
--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -27,7 +27,6 @@ import { ThemeType, themesOptions } from './theme'
 import { ConfirmInformation } from './ux/confirmInformation/ConfirmInformation'
 import ChooseNetworkComponent from './ux/chooseNetwork/ChooseNetworkComponent'
 import TutorialComponent from './ux/tutorial/TutorialComponent'
-import { Button } from './ui/shared/Button'
 import disconnectFromProvider from './lib/providerDisconnect'
 
 // copy-pasted and adapted
@@ -423,7 +422,6 @@ export class Core extends React.Component<IModalProps, IModalState> {
     */
    private closeModal () {
      const { onClose, providerController } = this.props
-     console.log('closing modal')
 
      // clean up the provider controller
      providerController.clearCachedProvider()

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -173,16 +173,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     return i18n.language
   }
 
-  public componentDidUpdate (prevProps: IModalProps, prevState: IModalState) {
-    /*
-    // this resets the state if an unhandled error closed the modal
-    console.log('componentDidUpdate', prevState.show, this.state.show)
-    if (this.state.currentStep === 'loading' && !prevState.show && this.state.show) {
-      console.log('componentDidUpdate closing()')
-      this.closeModal()
-    }
-    */
-
+  public componentDidUpdate (_prevProps: IModalProps, _prevState: IModalState) {
     if (this.lightboxRef) {
       const lightboxRect = this.lightboxRef.getBoundingClientRect()
       const lightboxOffset = lightboxRect.top > 0 ? lightboxRect.top : 0

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -126,7 +126,11 @@ export class RLogin {
     .then(() => this.eventController.trigger(event, ...args))
 
   /** event handlers */
-  private onClose = () => this.handleOnAndTrigger(CLOSE_EVENT)
+  private onClose = () => {
+    this.resetState()
+    this.handleOnAndTrigger(CLOSE_EVENT)
+  }
+
   private onConnect = (provider: any, disconnect: () => void, selectedLanguage:string, selectedTheme:themesOptions, dataVault?: DataVault) => this.handleOnAndTrigger(CONNECT_EVENT, { provider, disconnect, selectedLanguage, selectedTheme, dataVault })
   private onError = (error: any) => this.handleOnAndTrigger(ERROR_EVENT, error) // TODO: add a default error page
   private onAccountsChange = (accounts: string[]) => this.eventController.trigger(ACCOUNTS_CHANGED, accounts)
@@ -200,7 +204,7 @@ export class RLogin {
         return
       }
 
-      await this.toggleModal() // pre: the modal is closed
+      this.showModal()
     });
 
   /**

--- a/src/lib/providerDisconnect.ts
+++ b/src/lib/providerDisconnect.ts
@@ -1,0 +1,30 @@
+import { RLOGIN_ACCESS_TOKEN, RLOGIN_REFRESH_TOKEN, WALLETCONNECT } from '..'
+
+const disconnectProvider = async (provider: any): Promise<void> => {
+  if (!provider) {
+    return
+  }
+
+  // WalletConnect, Hardware Wrappers, Portis Wrapper
+  if (provider.disconnect) {
+    // could be a promise
+    await provider.disconnect()
+  }
+
+  // LocalStorage cleanup missed with the disconnect method
+  localStorage.removeItem(WALLETCONNECT)
+  localStorage.removeItem('WEB3_CONNECT_CACHED_PROVIDER')
+}
+
+const disconnectFromDataVault = () => {
+  localStorage.removeItem(RLOGIN_ACCESS_TOKEN)
+  localStorage.removeItem(RLOGIN_REFRESH_TOKEN)
+  localStorage.removeItem('x-csrf-token')
+}
+
+const disconnectFromProvider = (provider: any) => {
+  disconnectProvider(provider)
+  disconnectFromDataVault()
+}
+
+export default disconnectFromProvider


### PR DESCRIPTION
Creates two functions, one for disconnect and one to close the modal. Then code is cleaned up to use one of the two functions. Disconnect updates the state as appropriate, but then delegates to a file in `lib/` to disconnect from the provider and the datavault.

The `componentDidUpdate` code that was added in XXXX was removed. This code was a workaround because at the time we were not handling the errors from the provider.  #168 handles this scenario and the code is now duplicative. 

### failing test:

Cypress tests are currently failing because the provider error is not being handled. Once #168 is merged, and this PR is rebased into it, the failing tests will pass. 
