### PR TITLE
README: add chainId: 30 to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ export const rLogin = new RLogin({
     walletconnect: {
       package: WalletConnectProvider,
       options: {
-        rpc: rpcUrls
+        rpc: rpcUrls,
+        chainId: 30
       }
     },
     portis: {


### PR DESCRIPTION
It is important for dapps to configure the correct chainId in for walletconnect. Otherwise walletconnect requests Ethereum instead of RSK as a network from the wallet. Multichain wallets like Minerva would connect to Ethereum instead of RSK which makes it unusable.