### PR TITLE
Update README ledgerProviderOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ export const rLogin = new RLogin({
       options: {
         rpcUrl: 'https://public-node.testnet.rsk.co',
         chainId: 31
-      },
+       }
+    },
     'custom-dcent': dcentProviderOptions,
     'custom-trezor': {
       ...trezorProviderOptions,

--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ export const rLogin = new RLogin({
     torus: {
         package: Torus,
     },
-    'custom-ledger': ledgerProviderOptions,
+    'custom-ledger': {
+      ...ledgerProviderOptions,
+      options: {
+        rpcUrl: 'https://public-node.testnet.rsk.co',
+        chainId: 31
+      },
     'custom-dcent': dcentProviderOptions,
     'custom-trezor': {
       ...trezorProviderOptions,


### PR DESCRIPTION
ledgerProviderOptions needs the rpcUrl as described in the [rLogin Ledger Provider README](https://github.com/rsksmart/rLogin-providers/tree/develop/packages/rlogin-ledger-provider#implementation)

