### PR TITLE
connect has unhandled errors

### DIFF
--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -212,7 +212,7 @@ export class RLogin {
         }
 
         this.showModal()
-      } catch(err) {
+      } catch (err) {
         reject(err)
       }
     });

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -206,12 +206,15 @@ export class RLogin {
     // eslint-disable-next-line
     new Promise(async (resolve, reject) => { // weird async, to be refactored
       this.setupHandlers(resolve, reject)
+      try {
+        if (this.cachedProvider) {
+          await this.providerController.connectToCachedProvider()
+        }
 
-      if (this.cachedProvider) {
-        await this.providerController.connectToCachedProvider()
+        this.showModal()
+      } catch(err) {
+        reject(err)
       }
-
-      this.showModal()
     });
 
   /**


### PR DESCRIPTION
The connect function has unhandled errors, so if the user is waiting for a response to the connect promise it hangs

To reproduce this connect using rLogin with cachedProvider and metamask select the "don't ask me again" option. Once you are logged in deactivate the metamask extension.
Reload the page, when using connect rLogin will try to connect using the cachedProvider, it will fail as it is not accesible, it will print the error on the console, but it won't reject the promise, leaving the application waiting for connect to return a result or an error.

![Captura de pantalla de 2021-11-08 08-57-35](https://user-images.githubusercontent.com/3655076/141204079-7efb44b5-1f0f-4d6d-b360-861606ad5fd0.png)

This also happens if you connect using ledger, disconnect your device and then reload the page.

![Captura de pantalla de 2021-11-08 09-22-28](https://user-images.githubusercontent.com/3655076/141204096-f28b7738-352b-4c6d-97cf-4c6f5d3723a5.png)

