### PR TITLE
Add tests and return error if cachedProvider provider throws an error

### DIFF
--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -4,6 +4,12 @@ describe('sample:dapp testing, no backend', () => {
   const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
   const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
+  const rLoginCached = JSON.stringify({
+    "name": "MetaMask",
+    "logo": "data:image/svg+xml;",
+    "description": "Connect to your MetaMask Wallet"
+  })
+
   beforeEach(() => {
     cy.on('window:before:load', (win) => {
       win.ethereum = currentProvider({
@@ -30,6 +36,7 @@ describe('sample:dapp testing, no backend', () => {
       cy.visit('/?cache=yes', {
         onBeforeLoad: function (window) {
           window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.localStorage.setItem('RLOGIN_SELECTED_PROVIDER', rLoginCached)
         }
       })
 
@@ -54,6 +61,7 @@ describe('sample:dapp testing, no backend', () => {
       cy.visit('/?cache=yes', {
         onBeforeLoad: function (window) {
           window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.localStorage.setItem('RLOGIN_SELECTED_PROVIDER', rLoginCached)
           window.localStorage.setItem('RLogin:DontShowAgain', 'true')
         }
       })
@@ -76,17 +84,6 @@ describe('sample:dapp testing, no backend', () => {
   })
 
   describe('sample:permissioned', () => {
-    it('logs in with injected', () => {
-      cy.visit('/?cache=yes&backend=yes', {
-        onBeforeLoad: function (window) {
-          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
-        }
-      })
-
-      cy.get('#login').click()
-      cy.get('.rlogin-header2').should('have.text', 'Would you like to give us access to info in your data vault?')
-    })
-
     it('resets with a junk provider', () => {
       cy.visit('/?cache=yes&backend=yes', {
         onBeforeLoad: function (window) {

--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -1,13 +1,15 @@
 import currentProvider from '@rsksmart/mock-web3-provider'
 
-describe('sample:dapp testing, no backend', () => {
+describe('cache provider tests', () => {
   const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
   const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
   const rLoginCached = JSON.stringify({
-    "name": "MetaMask",
-    "logo": "data:image/svg+xml;",
-    "description": "Connect to your MetaMask Wallet"
+    provider: {
+      "name": "MetaMask",
+      "logo": "data:image/svg+xml;",
+      "description": "Connect to your MetaMask Wallet"
+    }
   })
 
   beforeEach(() => {
@@ -84,6 +86,18 @@ describe('sample:dapp testing, no backend', () => {
   })
 
   describe('sample:permissioned', () => {
+    it('logs in with injected', () => {
+      cy.visit('/?cache=yes&backend=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.localStorage.setItem('RLOGIN_SELECTED_PROVIDER', rLoginCached)
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('.rlogin-header2').should('have.text', 'Would you like to give us access to info in your data vault?')
+    })
+
     it('resets with a junk provider', () => {
       cy.visit('/?cache=yes&backend=yes', {
         onBeforeLoad: function (window) {

--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -1,0 +1,101 @@
+import currentProvider from '@rsksmart/mock-web3-provider'
+
+describe('sample:dapp testing, no backend', () => {
+  const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
+  const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
+
+  beforeEach(() => {
+    cy.on('window:before:load', (win) => {
+      win.ethereum = currentProvider({
+        address,
+        privateKey,
+        chainId: 31,
+        debug: true
+      })
+    })
+  })
+
+  it('logs in as normal', () => {
+    cy.visit('/?cache=yes')
+
+    cy.get('#login').click()
+    cy.contains('MetaMask').click()
+    cy.get('.rlogin-button.confirm').click()
+
+    cy.get('#connected').should('have.text', 'Yes')
+  })
+
+  describe('sample:dapp', () => {
+    it('logs in with localStorage set to injected', () => {
+      cy.visit('/?cache=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('.rlogin-button.confirm').click()
+
+      cy.get('#connected').should('have.text', 'Yes')
+    })
+
+    it('attempts to login in to a junk provider', () => {
+      cy.visit('/?cache=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', 'tacos')
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('.rlogin-header2').should('have.text', 'Connect your wallet')
+    })
+
+    it('logs in with localStorage set to injected, and do not show set true', () => {
+      cy.visit('/?cache=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.localStorage.setItem('RLogin:DontShowAgain', 'true')
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('#connected').should('have.text', 'Yes')
+    })
+
+    it('provider throws an error when connecting', () => {
+      cy.visit('/?cache=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.ethereum.request = (_props) => Promise.reject(new Error('rejected'))
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('.rlogin-header2').should('have.text', 'Connect your wallet')
+    })
+  })
+
+  describe('sample:permissioned', () => {
+    it('logs in with injected', () => {
+      cy.visit('/?cache=yes&backend=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('.rlogin-header2').should('have.text', 'Would you like to give us access to info in your data vault?')
+    })
+
+    it('resets with a junk provider', () => {
+      cy.visit('/?cache=yes&backend=yes', {
+        onBeforeLoad: function (window) {
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"tacos"')
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('.rlogin-header2').should('have.text', 'Connect your wallet')
+    })
+  })
+})

--- a/cypress/integration/2-sample-app/hardwareProvider_spec.js
+++ b/cypress/integration/2-sample-app/hardwareProvider_spec.js
@@ -1,0 +1,48 @@
+import currentProvider from '@rsksmart/mock-web3-provider'
+
+describe('hardware provider tests', () => {
+  const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
+  const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
+
+  const rLoginCached = JSON.stringify({
+    provider: {
+      name: 'Ledger',
+      logo: 'data:image/svg+xml;',
+      description: 'Connect to your Ledger Wallet'
+    },
+    chosenNetwork: {
+      rpcUrl: 'http://test.com',
+      chainId: 30
+    }
+  })
+
+  beforeEach(() => {
+    cy.on('window:before:load', (win) => {
+      const provider = currentProvider({
+        address,
+        privateKey,
+        chainId: 31,
+        debug: true
+      })
+
+      provider.isMetaMask = null
+      provider.isLedger = true
+
+      win.ethereum = provider
+    })
+  })
+
+  it('shows the choose network and tutorial screens', () => {
+    cy.visit('/?cache=yes')
+
+    cy.get('#login').click()
+    cy.contains('Ledger').click()
+    cy.get('.rlogin-header2').should('have.text', 'Choose Network')
+
+    cy.get('.rlogin-button').click()
+    cy.contains('Finish tutorial and connect').click()
+
+    // can't connect since the rLogin package attempts to connect via USB
+    cy.get('.rlogin-header2').should('have.text', 'Could not connect to Ledger')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.3.0-beta.2",
+  "version": "1.3.0-beta.3",
   "description": "rLogin - the web3.0 SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -122,8 +122,10 @@
           },
           'custom-trezor': {
             ...window.rLoginTrezorProvider.trezorProviderOptions,
-            manifestEmail: 'info@iovlabs.org',
-            manifestAppUrl: 'https://basic-sample.rlogin.identity.rifos.org/',
+            options: {
+              manifestEmail: 'info@iovlabs.org',
+              manifestAppUrl: 'https://rlogin-sample.rifos.org/',
+            }
           },
           'custom-dcent': {
             ...window.rLoginDCentProvider.dcentProviderOptions,

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -109,7 +109,10 @@ interface IModalState {
   dataVault?: IDataVault
   loadingReason?: string
   currentTheme?: themesOptions
-  selectedProviderUserOption?: IProviderUserOptions
+  selectedProviderUserOption?: {
+    provider: IProviderUserOptions,
+    chosenNetwork?: NetworkConnectionConfig
+  }
   chosenNetwork?: NetworkConnectionConfig
 }
 
@@ -298,11 +301,14 @@ export class Core extends React.Component<IModalProps, IModalState> {
          this.setState({
            currentStep: 'loading',
            loadingReason: `Connecting to ${providerName}`,
-           selectedProviderUserOption: provider
+           selectedProviderUserOption: { provider }
          })
 
          if (providerController?.shouldCacheProvider) {
-           setLocal(RLOGIN_SELECTED_PROVIDER, provider)
+           setLocal(RLOGIN_SELECTED_PROVIDER, {
+             provider,
+             chosenNetwork
+           })
          }
        })
        .catch((err: any) =>
@@ -484,8 +490,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
         big={currentStep === 'Step1'}
       >
         {currentStep === 'Step1' && <WalletProviders userProviders={userProviders} connectToWallet={this.preConnectChecklist} changeLanguage={this.changeLanguage} availableLanguages={this.availableLanguages} selectedLanguageCode={this.selectedLanguageCode} changeTheme={this.changeTheme} selectedTheme={this.selectedTheme} />}
-        {currentStep === 'Step2' && <SelectiveDisclosure sdr={sdr!} backendUrl={backendUrl!} fetchSelectiveDisclosureRequest={this.fetchSelectiveDisclosureRequest} onConfirm={this.onConfirmSelectiveDisclosure} providerName={selectedProviderUserOption?.name} />}
-        {['confirmInformation', 'walletInfo'].includes(currentStep) && <ConfirmInformation displayMode={currentStep === 'walletInfo'} chainId={chainId} address={address} provider={provider} providerUserOption={selectedProviderUserOption!} sd={sd} onConfirm={this.onConfirmAuth} onCancel={this.closeModal} providerName={selectedProviderUserOption?.name} />}
+        {currentStep === 'Step2' && <SelectiveDisclosure sdr={sdr!} backendUrl={backendUrl!} fetchSelectiveDisclosureRequest={this.fetchSelectiveDisclosureRequest} onConfirm={this.onConfirmSelectiveDisclosure} providerName={selectedProviderUserOption?.provider.name} />}
+        {['confirmInformation', 'walletInfo'].includes(currentStep) && <ConfirmInformation displayMode={currentStep === 'walletInfo'} chainId={chainId} address={address} provider={provider} providerUserOption={selectedProviderUserOption!.provider} sd={sd} onConfirm={this.onConfirmAuth} onCancel={this.closeModal} />}
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
         {currentStep === 'chooseNetwork' && <ChooseNetworkComponent networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={({ chainId, rpcUrl, networkParams }) => this.chooseNetwork({ chainId, rpcUrl, networkParams })} />}

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -209,6 +209,7 @@ export class RLogin {
 
       if (this.cachedProvider) {
         await this.providerController.connectToCachedProvider()
+          .catch(reject)
       }
 
       this.showModal()

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -208,11 +208,13 @@ export class RLoginProviderController {
     })
   };
 
-  public async connectToCachedProvider () {
-    const provider = this.getProvider(this.cachedProvider)
-    if (typeof provider !== 'undefined') {
-      await this.connectTo(provider.id, provider.connector)
-    }
+  public connectToCachedProvider () {
+    return new Promise((resolve, reject) => {
+      const provider = this.getProvider(this.cachedProvider)
+      typeof provider !== 'undefined'
+        ? resolve(this.connectTo(provider.id, provider.connector))
+        : reject(new Error('Provider not found'))
+    })
   }
 
   public on (event: string, callback: (result: any) => void): () => void {

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -210,9 +210,13 @@ export class RLoginProviderController {
 
   public connectToCachedProvider () {
     return new Promise((resolve, reject) => {
+      // get the optional options to be passed to the provider from localStorage
+      const cachedOptions = getLocal(RLOGIN_SELECTED_PROVIDER)
+      const optionalOpts = cachedOptions ? cachedOptions.chosenNetwork : {}
+
       const provider = this.getProvider(this.cachedProvider)
       typeof provider !== 'undefined'
-        ? resolve(this.connectTo(provider.id, provider.connector))
+        ? resolve(this.connectTo(provider.id, provider.connector, optionalOpts))
         : reject(new Error('Provider not found'))
     })
   }

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -21,12 +21,11 @@ interface ConfirmInformationProps {
   sd: SD | undefined
   providerUserOption: IProviderUserOptions
   provider: any
-  providerName?: string
   onConfirm: () => Promise<any>
   onCancel: () => void
 }
 
-export function ConfirmInformation ({ displayMode, chainId, address, providerUserOption, sd, provider, providerName, onConfirm, onCancel }: ConfirmInformationProps) {
+export function ConfirmInformation ({ displayMode, chainId, address, providerUserOption, sd, provider, onConfirm, onCancel }: ConfirmInformationProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [dontShowAgainSelected, setDontShowAgainSelected] = useState<boolean>(false)
   const data = sd ? Object.assign({}, sd.credentials, sd.claims) : {}
@@ -98,7 +97,7 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
         </>
       )}
     </>
-    : <ConfirmInWallet providerName={providerName || ''} />
+    : <ConfirmInWallet providerName={providerUserOption ? providerUserOption.name : ''} />
 }
 
 const Column = styled.div`

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -54,9 +54,11 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
     ? <>
       <Header2><Trans>Information</Trans></Header2>
       <CenterContent>
-        <LogoWrapper>
-          <img src={providerUserOption.logo} alt={providerUserOption.name} />
-        </LogoWrapper>
+        {providerUserOption && (
+          <LogoWrapper>
+            <img src={providerUserOption.logo} alt={providerUserOption.name} />
+          </LogoWrapper>
+        )}
         {peerWallet && <LogoWrapper>
           <img src={peerWallet.logo} alt={peerWallet.name} />
         </LogoWrapper>}


### PR DESCRIPTION
Return the error that the provider could throw to the dapp. Also, hide the images if the userProviderOptions is undefined.

This is similar to #195 but without the try/catch block.

Solves the following things:

- Returns an error if the cachedProvider throws an error while reconnecting
- Saves hardware chooseNetwork settings to be reused when connecting with the cachedProvider.
- Adds simple test for hardware wallets connecting normally. 

We are unable to test hardware wallet cachedProvider since the provider will throw an error. This error is sent back to the dapp, but the current workflow is to fallback to show the main connect screen. 