### PR TITLE
Custom dPath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",
+        "@rsksmart/rlogin-dpath": "^1.0.1",
         "@rsksmart/vc-json-schemas-parser": "^1.0.0",
         "@types/styled-components": "^5.1.3",
         "axios": "^0.21.1",
@@ -2742,6 +2743,11 @@
       "dependencies": {
         "eth-sig-util": "^3.0.1"
       }
+    },
+    "node_modules/@rsksmart/rlogin-dpath": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-dpath/-/rlogin-dpath-1.0.1.tgz",
+      "integrity": "sha512-97aalCxqCy6/JyE5eefka2isC9rU2hfvspQRfkvEVKB3zGJsC/xK0onDwCFH0kBCdkUn2K3lLO0GRnOStdbpIQ=="
     },
     "node_modules/@rsksmart/vc-json-schemas-parser": {
       "version": "1.0.1",
@@ -25070,6 +25076,11 @@
       "requires": {
         "eth-sig-util": "^3.0.1"
       }
+    },
+    "@rsksmart/rlogin-dpath": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-dpath/-/rlogin-dpath-1.0.1.tgz",
+      "integrity": "sha512-97aalCxqCy6/JyE5eefka2isC9rU2hfvspQRfkvEVKB3zGJsC/xK0onDwCFH0kBCdkUn2K3lLO0GRnOStdbpIQ=="
     },
     "@rsksmart/vc-json-schemas-parser": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",
+    "@rsksmart/rlogin-dpath": "^1.0.1",
     "@rsksmart/vc-json-schemas-parser": "^1.0.0",
     "@types/styled-components": "^5.1.3",
     "axios": "^0.21.1",

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -273,7 +273,6 @@ export class Core extends React.Component<IModalProps, IModalState> {
    }
 
   private chooseNetwork = (network: NetworkConnectionConfig) => {
-    console.log(network)
     this.setState({ chosenNetwork: network }, () => {
       return this.preTutorialChecklist()
     })

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -93,7 +93,12 @@ interface IAvailableLanguage {
   name: string
 }
 
-type NetworkConnectionConfig = { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }
+type NetworkConnectionConfig = {
+  chainId: number
+  rpcUrl?: string
+  dPath?: string
+  networkParams?:NetworkParams
+}
 
 interface IModalState {
   show: boolean
@@ -268,6 +273,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
    }
 
   private chooseNetwork = (network: NetworkConnectionConfig) => {
+    console.log(network)
     this.setState({ chosenNetwork: network }, () => {
       return this.preTutorialChecklist()
     })
@@ -491,10 +497,10 @@ export class Core extends React.Component<IModalProps, IModalState> {
       >
         {currentStep === 'Step1' && <WalletProviders userProviders={userProviders} connectToWallet={this.preConnectChecklist} changeLanguage={this.changeLanguage} availableLanguages={this.availableLanguages} selectedLanguageCode={this.selectedLanguageCode} changeTheme={this.changeTheme} selectedTheme={this.selectedTheme} />}
         {currentStep === 'Step2' && <SelectiveDisclosure sdr={sdr!} backendUrl={backendUrl!} fetchSelectiveDisclosureRequest={this.fetchSelectiveDisclosureRequest} onConfirm={this.onConfirmSelectiveDisclosure} providerName={selectedProviderUserOption?.provider.name} />}
-        {['confirmInformation', 'walletInfo'].includes(currentStep) && <ConfirmInformation displayMode={currentStep === 'walletInfo'} chainId={chainId} address={address} provider={provider} providerUserOption={selectedProviderUserOption!.provider} sd={sd} onConfirm={this.onConfirmAuth} onCancel={this.closeModal} />}
+        {['confirmInformation', 'walletInfo'].includes(currentStep) && <ConfirmInformation displayMode={currentStep === 'walletInfo'} chainId={chainId} address={address} provider={provider} providerName={provider.name} providerUserOption={selectedProviderUserOption!.provider} sd={sd} onConfirm={this.onConfirmAuth} onCancel={this.closeModal} />}
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
-        {currentStep === 'chooseNetwork' && <ChooseNetworkComponent networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={({ chainId, rpcUrl, networkParams }) => this.chooseNetwork({ chainId, rpcUrl, networkParams })} />}
+        {currentStep === 'chooseNetwork' && <ChooseNetworkComponent providerName={provider.name} networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={network => this.chooseNetwork(network)} />}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}
         {currentStep === 'loading' && <Loading text={loadingReason} />}
       </Modal>

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -203,7 +203,6 @@ export class RLoginProviderController {
 
     const opts = { network: this.network || undefined, ...providerOptions }
 
-    console.log(opts)
     return new Promise((resolve, reject) => {
       connector(providerPackage, opts)
         .then((provider: any) => {

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -148,7 +148,7 @@ export class RLoginProviderController {
           name,
           logo,
           description: getProviderDescription(provider),
-          onClick: (opts?: { chainId: number, rpcUrl?: string, networkParams?: NetworkParams }) => this.connectTo(id, connector, opts)
+          onClick: (opts?: { chainId: number, rpcUrl?: string, dPath?: string, networkParams?: NetworkParams }) => this.connectTo(id, connector, opts)
         })
       }
     })
@@ -186,7 +186,7 @@ export class RLoginProviderController {
   public connectTo = (
     id: string,
     connector: (providerPackage: any, opts: any) => Promise<any>,
-    optionalOpts?: { chainId?: number, rpcUrl?: string, networkParams?: any }
+    optionalOpts?: { chainId?: number, rpcUrl?: string, dPath?: string, networkParams?: any }
   ) => {
     const providerPackage = this.getProviderOption(id, 'package')
     const providerOptions = id !== 'portis' ? {
@@ -203,6 +203,7 @@ export class RLoginProviderController {
 
     const opts = { network: this.network || undefined, ...providerOptions }
 
+    console.log(opts)
     return new Promise((resolve, reject) => {
       connector(providerPackage, opts)
         .then((provider: any) => {

--- a/src/ux/ChooseDPath.tsx
+++ b/src/ux/ChooseDPath.tsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react'
+import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
+import { isLedger } from '../lib/hardware-wallets'
+import { WideBox } from '../ui/shared/Box'
+import { Button } from '../ui/shared/Button'
+
+export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: { dPath: string, setDPath: (dPpath: string) => void, providerName: string, selectedChainId: string }) => {
+  const [customDpathIndex, setCustomDpathIndex] = useState(5)
+
+  const DpathRow = ({ i }: { i: number }) => {
+    const dpath = getDPathByChainId(parseInt(selectedChainId), i, isLedger(providerName))
+    return <>Account {i}: {dpath} <Button variant='secondary' onClick={() => setDPath(dpath)}>use</Button><br /></>
+  }
+
+  useEffect(() => {
+    setDPath(getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)))
+  }, [selectedChainId])
+
+
+  return <WideBox>
+    <b>Using: <input type="text" className="final-dpath" value={dPath} onChange={e => setDPath(e.target.value)} /></b>
+    <p>
+      Standard base derivation path: {getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)).slice(0, -1)}
+      <br /><br />
+      <DpathRow i={0} />
+      <DpathRow i={1} />
+      <DpathRow i={2} />
+      <DpathRow i={3} />
+      <DpathRow i={4} />
+      <br />
+      Account <input type="number" className="dpath-custom-index" style={{ width: 40 }} value={customDpathIndex} onChange={e => setCustomDpathIndex(parseInt(e.target.value))}  /><br />
+      <DpathRow i={customDpathIndex} />
+    </p>
+  </WideBox>
+}
+
+export const initialDPath = (selectedChainId: string, providerName: string) => getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)).slice(2)

--- a/src/ux/ChooseDPath.tsx
+++ b/src/ux/ChooseDPath.tsx
@@ -1,35 +1,98 @@
 import React, { useState, useEffect } from 'react'
+import styled from 'styled-components'
 import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 import { isLedger } from '../lib/hardware-wallets'
 import { WideBox } from '../ui/shared/Box'
-import { Button } from '../ui/shared/Button'
+import { Paragraph } from '../ui/shared/Typography'
+
+interface DpathRowInterface {
+  i: number,
+  dpath: string,
+  onClick: () => void,
+  selected: boolean
+}
+
+const DpathRowStyles = styled.button<{ selected: boolean }>`
+  background: ${(props) => props.selected ? props.theme.overlay : props.theme.primaryText};
+  border: none;
+  border-radius: 5px;
+  padding: 5px;
+  font-weight: 400 !important;
+  font-size: 12px;
+  color: ${(props) => props.selected ? props.theme.primaryText : props.theme.p};
+  width: 100%;
+  cursor: pointer
+`
+
+const DPathInput = styled.input`
+  border: none;
+  border-bottom: ${(props) => `1px solid ${props.theme.p}`};
+  color: ${props => props.theme.p};
+  padding: 5px;
+  margin-left: 10px;
+  &:focus {
+    outline: none;
+}
+`
+
+const DpathRow = ({ i, dpath, selected, onClick }: DpathRowInterface) =>
+  <DpathRowStyles onClick={onClick} selected={selected}>
+    Account {i} : {dpath}
+  </DpathRowStyles>
 
 export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: { dPath: string, setDPath: (dPpath: string) => void, providerName: string, selectedChainId: string }) => {
   const [customDpathIndex, setCustomDpathIndex] = useState(5)
-
-  const DpathRow = ({ i }: { i: number }) => {
-    const dpath = getDPathByChainId(parseInt(selectedChainId), i, isLedger(providerName))
-    return <>Account {i}: {dpath} <Button variant='secondary' onClick={() => setDPath(dpath)}>use</Button><br /></>
-  }
+  const customDpathPath = getDPathByChainId(parseInt(selectedChainId), customDpathIndex || 0, isLedger(providerName))
 
   useEffect(() => {
     setDPath(getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)))
   }, [selectedChainId])
 
+  const handleCustomChange = (e: any) => {
+    const customPath = parseInt(e.target.value)
+    setCustomDpathIndex(customPath)
+    customPath !== 0 && setDPath(getDPathByChainId(customPath, 0, isLedger(providerName)))
+  }
+
   return <WideBox>
-    <b>Using: <input type="text" className="final-dpath" value={dPath} onChange={e => setDPath(e.target.value)} /></b>
-    <p>
+    <Paragraph>Using:
+      <DPathInput
+        type="text"
+        className="final-dpath"
+        value={dPath}
+        onChange={e => setDPath(e.target.value)}
+      />
+    </Paragraph>
+
+    <Paragraph>
       Standard base derivation path: {getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)).slice(0, -1)}
-      <br /><br />
-      <DpathRow i={0} />
-      <DpathRow i={1} />
-      <DpathRow i={2} />
-      <DpathRow i={3} />
-      <DpathRow i={4} />
-      <br />
-      Account <input type="number" className="dpath-custom-index" style={{ width: 40 }} value={customDpathIndex} onChange={e => setCustomDpathIndex(parseInt(e.target.value))} /><br />
-      <DpathRow i={customDpathIndex} />
-    </p>
+    </Paragraph>
+    {Array.from({ length: 4 }, (_, i) => {
+      const dpath = getDPathByChainId(parseInt(selectedChainId), i, isLedger(providerName))
+      return <DpathRow
+        key={i}
+        i={i}
+        dpath={dpath}
+        onClick={() => setDPath(dpath)}
+        selected={dpath === dPath}
+      />
+    })}
+
+    <Paragraph>
+      Custom Account:
+      <DPathInput
+        type="number"
+        className="dpath-custom-index"
+        value={customDpathIndex}
+        onChange={handleCustomChange}
+      />
+      <DpathRow
+        i={customDpathIndex || 0}
+        dpath={customDpathPath}
+        onClick={() => setDPath(customDpathPath)}
+        selected={customDpathPath === dPath}
+      />
+    </Paragraph>
   </WideBox>
 }
 

--- a/src/ux/ChooseDPath.tsx
+++ b/src/ux/ChooseDPath.tsx
@@ -16,7 +16,6 @@ export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: 
     setDPath(getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)))
   }, [selectedChainId])
 
-
   return <WideBox>
     <b>Using: <input type="text" className="final-dpath" value={dPath} onChange={e => setDPath(e.target.value)} /></b>
     <p>
@@ -28,7 +27,7 @@ export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: 
       <DpathRow i={3} />
       <DpathRow i={4} />
       <br />
-      Account <input type="number" className="dpath-custom-index" style={{ width: 40 }} value={customDpathIndex} onChange={e => setCustomDpathIndex(parseInt(e.target.value))}  /><br />
+      Account <input type="number" className="dpath-custom-index" style={{ width: 40 }} value={customDpathIndex} onChange={e => setCustomDpathIndex(parseInt(e.target.value))} /><br />
       <DpathRow i={customDpathIndex} />
     </p>
   </WideBox>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -10,7 +10,8 @@ describe('Component: ChooseNetworkComponent', () => {
       30: 'http://30',
       31: 'http://31'
     },
-    chooseNetwork: jest.fn()
+    chooseNetwork: jest.fn(),
+    providerName: 'provider'
   }
 
   it('renders the component', () => {

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-use-before-define
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Trans } from 'react-i18next'
 
 import { Header2, SmallSpan } from '../../ui/shared/Typography'
@@ -54,10 +54,10 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
           <SmallSpan><Trans>Change derivation path</Trans></SmallSpan>
         </label>
         {dpathEnabled && <ChooseDPath {...{ dPath, setDPath, providerName, selectedChainId }} />}
-        <p>
-          <Button onClick={handleSelect}>Choose</Button>
-        </p>
       </>}
+      <p>
+        <Button onClick={handleSelect}>Choose</Button>
+      </p>
     </div>
   )
 }

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -1,31 +1,42 @@
 // eslint-disable-next-line no-use-before-define
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Trans } from 'react-i18next'
 
-import { Header2 } from '../../ui/shared/Typography'
+import { Header2, SmallSpan } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
 import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
+import Checkbox from '../../ui/shared/Checkbox'
+import { ChooseDPath, initialDPath } from '../ChooseDPath'
+import { isHardwareWalletProvider } from '../../lib/hardware-wallets'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
   networkParamsOptions?: NetworkParamsAllOptions
-  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }) => void
+  chooseNetwork: (network: { chainId: number, rpcUrl?: string, dPath?: string, networkParams?:NetworkParams }) => void
+  providerName: string
 }
 
 const ChooseNetworkComponent: React.FC<Interface> = ({
   rpcUrls,
   networkParamsOptions,
-  chooseNetwork
+  chooseNetwork,
+  providerName
 }) => {
   if (!rpcUrls) {
     return <></>
   }
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
 
+  const [dpathEnabled, setDpathEnabled] = useState(false)
+  const [dPath, setDPath] = useState(initialDPath(selectedChainId, providerName))
+
+  console.log(dpathEnabled)
+  console.log(dPath)
+
   const handleSelect = () =>
-    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
+    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], dPath: !dpathEnabled ? undefined : dPath, networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
 
   return (
     <div>
@@ -37,9 +48,16 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
           )}
         </Select>
       </p>
-      <p>
-        <Button onClick={handleSelect}>Choose</Button>
-      </p>
+      {isHardwareWalletProvider(providerName) && <>
+        <label>
+          <Checkbox checked={dpathEnabled} onChange={() => setDpathEnabled(!dpathEnabled)} />
+          <SmallSpan><Trans>Change derivation path</Trans></SmallSpan>
+        </label>
+        {dpathEnabled && <ChooseDPath {...{ dPath, setDPath, providerName, selectedChainId }} />}
+        <p>
+          <Button onClick={handleSelect}>Choose</Button>
+        </p>
+      </>}
     </div>
   )
 }

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -32,9 +32,6 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
   const [dpathEnabled, setDpathEnabled] = useState(false)
   const [dPath, setDPath] = useState(initialDPath(selectedChainId, providerName))
 
-  console.log(dpathEnabled)
-  console.log(dPath)
-
   const handleSelect = () =>
     chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], dPath: !dpathEnabled ? undefined : dPath, networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
 

--- a/src/ux/confirmInformation/ConfirmInformation.test.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.test.tsx
@@ -122,9 +122,9 @@ describe('Component: ConfirmInformation', () => {
   })
 
   it('shows dpath for hardware provider', () => {
-    const wrapper = mount(<ConfirmInformation {...props} providerName='Ledger' provider={{ dPath: 'dpath' }} />)
+    const wrapper = mount(<ConfirmInformation {...props} providerName='Ledger' provider={{ dpath: 'dpath', isLedger: true }} />)
 
-    expect(wrapper.find(`dt.${LIST_TITLE}`).at(3).text()).toBe('Derivation path:')
-    expect(wrapper.find(`dd.${LIST_DESCRIPTION}`).at(3).text()).toBe('dpath')
+    expect(wrapper.find(`dt.${LIST_TITLE}`).at(2).text()).toBe('Derivation path:')
+    expect(wrapper.find(`dd.${LIST_DESCRIPTION}`).at(2).text()).toBe('dpath')
   })
 })

--- a/src/ux/confirmInformation/ConfirmInformation.test.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.test.tsx
@@ -12,6 +12,7 @@ describe('Component: ConfirmInformation', () => {
     providerUserOption,
     sd: undefined,
     provider: undefined,
+    providerName: 'provider',
     onConfirm: jest.fn(),
     onCancel: jest.fn(),
     displayMode: false
@@ -118,5 +119,12 @@ describe('Component: ConfirmInformation', () => {
     expect(confirmButton).toBe(false)
     expect(cancelButton).toBe(false)
     expect(checkbox).toBe(false)
+  })
+
+  it('shows dpath for hardware provider', () => {
+    const wrapper = mount(<ConfirmInformation {...props} providerName='Ledger' provider={{ dPath: 'dpath' }} />)
+
+    expect(wrapper.find(`dt.${LIST_TITLE}`).at(3).text()).toBe('Derivation path:')
+    expect(wrapper.find(`dd.${LIST_DESCRIPTION}`).at(3).text()).toBe('dpath')
   })
 })

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -79,7 +79,7 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
           <Description>{shortAddress(address)}</Description>
           {peerWallet && <Description>{peerWallet.name}</Description>}
           <Description>{chainId && getChainName(chainId)}</Description>
-          {isHardwareWallet && <Description>{provider.dpath}</Description>}
+          {isHardwareWallet && <Description>{provider.dpath || provider.path}</Description>}
           {sd && Object.keys(sd.claims).map(key => <Description key={`claim-value-${key}`}>{data[key]}</Description>)}
           {sd && Object.keys(sd.credentials).map(key => <Description key={`credential-value-${key}`}>{credentialValueToText(key, data[key])}</Description>)}
         </Column>

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -50,7 +50,7 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
 
   const peerWallet = getPeerInfo(provider?.wc?.peerMeta)
 
-  const isHardwareWallet = provider.isLedger || provider.isTrezor || provider.isDCent
+  const isHardwareWallet = provider?.isLedger || provider?.isTrezor || provider?.isDCent
 
   return !isLoading
     ? <>

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -21,11 +21,12 @@ interface ConfirmInformationProps {
   sd: SD | undefined
   providerUserOption: IProviderUserOptions
   provider: any
+  providerName: string
   onConfirm: () => Promise<any>
   onCancel: () => void
 }
 
-export function ConfirmInformation ({ displayMode, chainId, address, providerUserOption, sd, provider, onConfirm, onCancel }: ConfirmInformationProps) {
+export function ConfirmInformation ({ displayMode, chainId, address, providerUserOption, sd, provider, providerName, onConfirm, onCancel }: ConfirmInformationProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [dontShowAgainSelected, setDontShowAgainSelected] = useState<boolean>(false)
   const data = sd ? Object.assign({}, sd.credentials, sd.claims) : {}
@@ -49,6 +50,8 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
 
   const peerWallet = getPeerInfo(provider?.wc?.peerMeta)
 
+  const isHardwareWallet = provider.isLedger || provider.isTrezor || provider.isDCent
+
   return !isLoading
     ? <>
       <Header2><Trans>Information</Trans></Header2>
@@ -68,6 +71,7 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
           <Title><Trans>Wallet address</Trans>:</Title>
           {peerWallet && <Title><Trans>Connected wallet</Trans>:</Title>}
           <Title><Trans>Network</Trans>:</Title>
+          {isHardwareWallet && <Title><Trans>Derivation path</Trans>:</Title>}
           {sd && Object.keys(sd.claims).map(key => <Title key={`claim-key-${key}`}>{key}:</Title>)}
           {sd && Object.keys(sd.credentials).map(key => <Title key={`credential-key-${key}`}>{key}:</Title>)}
         </Column>
@@ -75,6 +79,7 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
           <Description>{shortAddress(address)}</Description>
           {peerWallet && <Description>{peerWallet.name}</Description>}
           <Description>{chainId && getChainName(chainId)}</Description>
+          {isHardwareWallet && <Description>{provider.dpath}</Description>}
           {sd && Object.keys(sd.claims).map(key => <Description key={`claim-value-${key}`}>{data[key]}</Description>)}
           {sd && Object.keys(sd.credentials).map(key => <Description key={`credential-value-${key}`}>{credentialValueToText(key, data[key])}</Description>)}
         </Column>


### PR DESCRIPTION
Adds dPath selection in 'Choose Network' step

> The traditional UX lets the user see the address associated to the derivation path in the "addresses table". This is not possible with the given `rLogin-providers` implementation. For that UX we should make a bigger change.
<img width="470" alt="Screen Shot 2021-12-22 at 21 34 52" src="https://user-images.githubusercontent.com/36084092/147170417-5a886143-7523-4fc4-a0d1-680884268eae.png">
<img width="457" alt="Screen Shot 2021-12-22 at 21 36 10" src="https://user-images.githubusercontent.com/36084092/147170425-e11d6c0e-fe19-4888-8b46-041dbb6af62d.png">

