### PR TITLE
Show balance and address with dPath selection

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          build: npm run build
           start: npm run sample:permissioned
           record: false
         env:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           build: npm run build
           start: npm run sample:permissioned
-          record: true
+          record: false
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          start: npm run sample:permissioned
+          build: npm run build
+          start: npm run sample:cypress
           record: false
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.3.1-beta.1",
+  "version": "1.3.1-beta.2",
   "description": "Login tool for RSK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sample:dapp": "concurrently \"npm run build:dev\" \"node sample/launcher.js\" \"serve dist -l 3005\" \"serve sample/front -l 3006\"",
     "sample:open": "concurrently \"npm run build:dev\" \"node sample/launcher.js backend\" \"serve dist -l 3005\" \"serve sample/front -l 3006\" \"nodemon --watch sample/back sample/back/index.js\"",
     "sample:permissioned": "concurrently \"npm run build:dev\" \"node sample/launcher.js backend\" \"serve dist -l 3005\" \"serve sample/front -l 3006\" \"nodemon --watch sample/back sample/back/index.js permissioned\"",
+    "sample:cypress": "concurrently \"node sample/launcher.js backend\" \"serve dist -l 3005\" \"serve sample/front -l 3006\" \"nodemon --watch sample/back sample/back/index.js permissioned\"",
     "serve": "serve dist -l 3005",
     "prepublish": "npm run build"
   },

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -56,8 +56,8 @@
     <script src="https://unpkg.com/@toruslabs/torus-embed@1.13.4/dist/torus.umd.min.js" integrity="sha256-PYFNxx1jq9Yra6tv1R5bB+VBP3lxSQG+aGie+UcVYro=" crossorigin="anonymous"></script>
 
     <!-- Hardware -->
-    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.0-beta.8/dist/bundle.js" integrity="sha384-m/q7N5NZG7fIxx00ult4A74N/jPFwgG564OiwXPPXpdHzu1i5BAyxPA4535U/Yqs" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@rsksmart/rlogin-trezor-provider@1.0.0-beta.9/dist/bundle.js" integrity="sha384-rr3MHx1XrgmOTDi1vXLwgGmAr5U7UXddzRRZNwU53MWO817EY6yucdp4imrHdMeD" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.2-beta.3/dist/bundle.js" integrity="sha384-mD7EobztXceQUROLOeYJS36lqvRZbfGDg1tdcBYX9YY0dN0yqt1CtoQZLRS5PJUv" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-trezor-provider@1.0.2-beta.3/dist/bundle.js" integrity="sha384-FSSAPsXg4nmFYE/Mel1CC06UBlkzpzIPGUkKiPKeQTCv7po35OvCgUE44AVRTH3i" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/@rsksmart/rlogin-dcent-provider@1.0.0-beta.8/dist/bundle.js" integrity="sha384-Zt1JFaeCbx2cs8Cu7N/4gYXPBB33TlqZoJlqboFo+vJuerwJcOGWzm2Xd8lpOWG2" crossorigin="anonymous"></script>
 
     <!-- RIF Data Vault Client -->

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -518,7 +518,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
         {currentStep === 'chooseNetwork' && <ChooseNetworkComponent providerName={provider.name} networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={this.chooseNetwork} />}
-        {currentStep === 'choosePath' && <ChooseDPathComponent provider={provider} selectPath={this.setHardwareDPath} />}
+        {currentStep === 'choosePath' && <ChooseDPathComponent provider={provider} selectPath={this.setHardwareDPath} handleError={(err: any) => this.setState({ currentStep: 'error', errorReason: { title: 'Error Selecting Path', description: err.toString() } })} />}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}
         {currentStep === 'loading' && <Loading text={loadingReason} />}
       </Modal>

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -12,7 +12,7 @@ import { ErrorMessage } from './ui/shared/ErrorMessage'
 import { ACCOUNTS_CHANGED, CHAIN_CHANGED, CONNECT_EVENT, ERROR_EVENT } from './constants/events'
 import { getDID, getChainId } from './adapters'
 import { addEthereumChain, ethAccounts, ethChainId, isMetamask } from './lib/provider'
-import { isHardwareWalletProvider, requiresNetworkSelection, getTutorialLocalStorageKey, PROVIDERS_NETWORK_PARAMS } from './lib/hardware-wallets'
+import { isHardwareWalletProvider, requiresNetworkSelection, getTutorialLocalStorageKey, PROVIDERS_NETWORK_PARAMS, requiresAccountSelection } from './lib/hardware-wallets'
 import { confirmAuth, requestSignup } from './lib/did-auth'
 import { createDataVault } from './lib/data-vault'
 import { fetchSelectiveDisclosureRequest } from './lib/sdr'
@@ -226,7 +226,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
    * After connecting to the provider but before detecting the flavor
    */
   private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => {
-    if (provider.chooseAccount) {
+    if (requiresAccountSelection(provider)) {
       return this.setState({ currentStep: 'choosePath' })
     }
 

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -235,9 +235,6 @@ export class Core extends React.Component<IModalProps, IModalState> {
     }
   })
 
-  private setHardwareDPath = (address: string) =>
-    this.setState({ address }, this.detectFlavor)
-
   private validateCurrentChain ():boolean {
     const { supportedChains, showModal, keepModalHidden, onError } = this.props
     const { chainId, provider } = this.state
@@ -287,9 +284,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
      })
    }
 
-  private chooseNetwork = (network: NetworkConnectionConfig) => {
+  private chooseNetwork = (network: NetworkConnectionConfig) =>
     this.setState({ chosenNetwork: network }, this.preTutorialChecklist)
-  }
 
   /**
    * Checklist before sending the connect method
@@ -521,7 +517,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {currentStep === 'choosePath' && (
           <ChooseDPathComponent
             provider={provider}
-            selectPath={this.setHardwareDPath}
+            selectPath={(address: string) => this.setState({ address }, this.detectFlavor)}
             handleError={(err: any) => this.setState({ currentStep: 'error', errorReason: { title: 'Error Selecting Path', description: err.toString() } })} />
         )}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -226,7 +226,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
    * After connecting to the provider but before detecting the flavor
    */
   private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => {
-    if (provider.isLedger) {
+    if (provider.chooseAccount) {
       return this.setState({ currentStep: 'choosePath' })
     }
 

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -241,9 +241,17 @@ export class Core extends React.Component<IModalProps, IModalState> {
     }
   })
 
-  private setHardwareDPath = (dPath: string) => {
-    console.log('dPath has been set up, detect flavor', dPath)
-    // const { selectedProviderUserOption } = this.state
+  private setHardwareDPath = ({ address, dPath }: { address: string, dPath: string }) => {
+    const { selectedProviderUserOption } = this.state
+
+    this.setState({
+      address,
+      // @ts-ignore - selectedProviderUserOption exists
+      selectedProviderUserOption: {
+        ...selectedProviderUserOption,
+        dPath
+      }
+    }, this.detectFlavor)
   }
 
   private validateCurrentChain ():boolean {
@@ -523,7 +531,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
         {currentStep === 'chooseNetwork' && <ChooseNetworkComponent networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={network => this.chooseNetwork(network)} />}
-        {currentStep === 'choosePath' && <ChooseDPathComponent provider={provider} />}
+        {currentStep === 'choosePath' && <ChooseDPathComponent provider={provider} selectPath={this.setHardwareDPath} />}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}
         {currentStep === 'loading' && <Loading text={loadingReason} />}
       </Modal>

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -31,6 +31,7 @@ import disconnectFromProvider from './lib/providerDisconnect'
 import { NetworkParams } from './lib/networkOptionsTypes'
 import { Button } from './ui/shared/Button'
 import { RLOGIN_SELECTED_PROVIDER } from './constants'
+import { ChooseDPathComponent } from './ux/chooseDpath/ChooseDPath'
 
 // copy-pasted and adapted
 // https://github.com/Web3Modal/web3modal/blob/4b31a6bdf5a4f81bf20de38c45c67576c3249bfc/src/components/Modal.tsx
@@ -80,7 +81,7 @@ interface IModalProps {
   rpcUrls?: {[key: string]: string}
 }
 
-type Step = 'Step1' | 'Step2' | 'confirmInformation' | 'walletInfo' | 'error' | 'wrongNetwork' | 'chooseNetwork' | 'loading' | 'tutorial'
+type Step = 'Step1' | 'Step2' | 'confirmInformation' | 'walletInfo' | 'error' | 'wrongNetwork' | 'chooseNetwork' | 'choosePath' | 'loading' | 'tutorial'
 
 interface ErrorDetails {
   title: string
@@ -96,7 +97,6 @@ interface IAvailableLanguage {
 type NetworkConnectionConfig = {
   chainId: number
   rpcUrl?: string
-  dPath?: string
   networkParams?:NetworkParams
 }
 
@@ -116,6 +116,7 @@ interface IModalState {
   currentTheme?: themesOptions
   selectedProviderUserOption?: {
     provider: IProviderUserOptions,
+    dPath?: string
     chosenNetwork?: NetworkConnectionConfig
   }
   chosenNetwork?: NetworkConnectionConfig
@@ -221,7 +222,29 @@ export class Core extends React.Component<IModalProps, IModalState> {
     return this.validateCurrentChain()
   }
 
-  private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => { if (success) { return this.detectFlavor() } })
+  /**
+   * ContinueSettingUp
+   * After connecting to the provider but before detecting the flavor
+   */
+  private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => {
+    const { selectedProviderUserOption } = this.state
+    if (
+      selectedProviderUserOption &&
+      isHardwareWalletProvider(selectedProviderUserOption.provider.name) &&
+      !selectedProviderUserOption?.dPath
+    ) {
+      return this.setState({ currentStep: 'choosePath' })
+    }
+
+    if (success) {
+      return this.detectFlavor()
+    }
+  })
+
+  private setHardwareDPath = (dPath: string) => {
+    console.log('dPath has been set up, detect flavor', dPath)
+    // const { selectedProviderUserOption } = this.state
+  }
 
   private validateCurrentChain ():boolean {
     const { supportedChains, showModal, keepModalHidden, onError } = this.props
@@ -499,7 +522,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {['confirmInformation', 'walletInfo'].includes(currentStep) && <ConfirmInformation displayMode={currentStep === 'walletInfo'} chainId={chainId} address={address} provider={provider} providerName={provider.name} providerUserOption={selectedProviderUserOption!.provider} sd={sd} onConfirm={this.onConfirmAuth} onCancel={this.closeModal} />}
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
-        {currentStep === 'chooseNetwork' && <ChooseNetworkComponent providerName={provider.name} networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={network => this.chooseNetwork(network)} />}
+        {currentStep === 'chooseNetwork' && <ChooseNetworkComponent networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={network => this.chooseNetwork(network)} />}
+        {currentStep === 'choosePath' && <ChooseDPathComponent provider={provider} />}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}
         {currentStep === 'loading' && <Loading text={loadingReason} />}
       </Modal>

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -119,7 +119,6 @@ interface IModalState {
     chosenNetwork?: NetworkConnectionConfig
   }
   chosenNetwork?: NetworkConnectionConfig
-  setupDpath?: boolean
 }
 
 const INITIAL_STATE: IModalState = {
@@ -225,10 +224,9 @@ export class Core extends React.Component<IModalProps, IModalState> {
   /**
    * ContinueSettingUp
    * After connecting to the provider but before detecting the flavor
-   * */
+   */
   private continueSettingUp = (provider: any) => this.setupProvider(provider).then((success) => {
-    const { setupDpath } = this.state
-    if (setupDpath) {
+    if (provider.isLedger) {
       return this.setState({ currentStep: 'choosePath' })
     }
 
@@ -289,11 +287,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
      })
    }
 
-  private chooseNetwork = (network: NetworkConnectionConfig, setupDpath: boolean) => {
-    this.setState({
-      chosenNetwork: network,
-      setupDpath
-    }, this.preTutorialChecklist)
+  private chooseNetwork = (network: NetworkConnectionConfig) => {
+    this.setState({ chosenNetwork: network }, this.preTutorialChecklist)
   }
 
   /**
@@ -517,8 +512,18 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {['confirmInformation', 'walletInfo'].includes(currentStep) && <ConfirmInformation displayMode={currentStep === 'walletInfo'} chainId={chainId} address={address} provider={provider} providerName={provider.name} providerUserOption={selectedProviderUserOption!.provider} sd={sd} onConfirm={this.onConfirmAuth} onCancel={this.closeModal} />}
         {currentStep === 'error' && <ErrorMessage title={errorReason?.title} description={errorReason?.description} footerCta={errorReason?.footerCta} />}
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
-        {currentStep === 'chooseNetwork' && <ChooseNetworkComponent providerName={provider.name} networkParamsOptions ={ networkParamsOptions } rpcUrls={rpcUrls} chooseNetwork={this.chooseNetwork} />}
-        {currentStep === 'choosePath' && <ChooseDPathComponent provider={provider} selectPath={this.setHardwareDPath} handleError={(err: any) => this.setState({ currentStep: 'error', errorReason: { title: 'Error Selecting Path', description: err.toString() } })} />}
+        {currentStep === 'chooseNetwork' && (
+          <ChooseNetworkComponent
+            networkParamsOptions={networkParamsOptions}
+            rpcUrls={rpcUrls}
+            chooseNetwork={this.chooseNetwork} />
+        )}
+        {currentStep === 'choosePath' && (
+          <ChooseDPathComponent
+            provider={provider}
+            selectPath={this.setHardwareDPath}
+            handleError={(err: any) => this.setState({ currentStep: 'error', errorReason: { title: 'Error Selecting Path', description: err.toString() } })} />
+        )}
         {currentStep === 'tutorial' && <TutorialComponent providerName={provider.name} handleConnect={this.connectToWallet} />}
         {currentStep === 'loading' && <Loading text={loadingReason} />}
       </Modal>

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -237,7 +237,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     }
   })
 
-  private setHardwareDPath = ({ address, dPath }: { address: string, dPath: string }) =>
+  private setHardwareDPath = (address: string) =>
     this.setState({ address }, this.detectFlavor)
 
   private validateCurrentChain ():boolean {

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -23,4 +23,13 @@ export function getChainName (chainId: number) {
   }
 }
 
+export const getGasNameFromChain = (chainId: number) => {
+  switch (chainId) {
+    case 1: return 'ETH'
+    case 30: return 'RBTC'
+    case 31: return 'tRBTC'
+    default: return ''
+  }
+}
+
 export const getChainId = (chainId: string) => parseInt(chainId)

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -61,7 +61,12 @@ const resources = {
       'Trezor Bridge': 'Trezor Bridge',
       // DCent tutorial
       'Plug in your D\'Cent device': 'Plug in your D\'Cent device',
-      'D\'Cent Bridge will pop up. Follow the insttructions to connect your device.': 'D\'Cent Bridge will pop up. Follow the insttructions to connect your device.'
+      'D\'Cent Bridge will pop up. Follow the insttructions to connect your device.': 'D\'Cent Bridge will pop up. Follow the insttructions to connect your device.',
+      'Select an account': 'Select an account',
+      Path: 'Path',
+      Address: 'Address',
+      Balance: 'Balance',
+      'Or use the textbox to choose a specific path:': 'Or use the textbox to choose a specific path:'
     }
   },
   es: {

--- a/src/lib/hardware-wallets.ts
+++ b/src/lib/hardware-wallets.ts
@@ -44,6 +44,10 @@ export function requiresNetworkSelection (providerName: string) {
   return isHardwareWalletProvider(providerName) || isTorus(providerName) || isPortis(providerName)
 }
 
+export function requiresAccountSelection (provider: any) {
+  return (provider.isLedger || provider.isTrezor) && provider.chooseAccount
+}
+
 const TORUS_NETWORK_PARAMS: NetworkParamsOptions<TorusNetworkParams> = {
   30: {
     host: 'https://public-node.rsk.co',

--- a/src/ux/chooseDpath/AccountRow.tsx
+++ b/src/ux/chooseDpath/AccountRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import BN from 'bn.js'
 import { shortAddress } from '../confirmInformation/ConfirmInformation'
 import { AccountInterface } from './ChooseDPath'
 
@@ -10,10 +11,12 @@ interface Interface {
 }
 
 const DpathRowStyles = styled.button<{ selected: boolean }>`
+  display: flex;
   background: ${(props) => props.selected ? props.theme.overlay : props.theme.primaryText};
   border: none;
   border-radius: 5px;
   padding: 5px;
+  margin-bottom: 5px;
   font-weight: 400 !important;
   font-size: 12px;
   color: ${(props) => props.selected ? props.theme.primaryText : props.theme.p};
@@ -21,13 +24,25 @@ const DpathRowStyles = styled.button<{ selected: boolean }>`
   cursor: pointer
 `
 
-const AccountRow: React.FC<Interface> = ({ account, selected, onClick }: Interface) =>
-  <DpathRowStyles onClick={onClick} selected={selected}>
-    {account.dPath}
-    :
-    {shortAddress(account.address)}
-    :
-    {account.balance}
+const Column = styled.div`
+  width: 33%;
+  text-align: left;
+  padding: 0 5px;
+`
+
+const AccountRow: React.FC<Interface> = ({ account, selected, onClick }: Interface) => {
+  const balance = account.balance && account.balance.startsWith('0x')
+    ? new BN(account.balance.substring(2), 16)
+    : new BN(account.balance || 0, 16)
+
+  // BN.js does not handle decimals
+  const niceBalance = balance.toNumber() / 1000000000000000000
+
+  return <DpathRowStyles onClick={onClick} selected={selected}>
+    <Column>{account.dPath}</Column>
+    <Column>{shortAddress(account.address)}</Column>
+    <Column>{niceBalance.toString().substring(0, 10)} RBTC</Column>
   </DpathRowStyles>
+}
 
 export default AccountRow

--- a/src/ux/chooseDpath/AccountRow.tsx
+++ b/src/ux/chooseDpath/AccountRow.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import styled from 'styled-components'
+import { shortAddress } from '../confirmInformation/ConfirmInformation'
+import { AccountInterface } from './ChooseDPath'
+
+interface Interface {
+  account: AccountInterface
+  onClick: () => void,
+  selected: boolean
+}
+
+const DpathRowStyles = styled.button<{ selected: boolean }>`
+  background: ${(props) => props.selected ? props.theme.overlay : props.theme.primaryText};
+  border: none;
+  border-radius: 5px;
+  padding: 5px;
+  font-weight: 400 !important;
+  font-size: 12px;
+  color: ${(props) => props.selected ? props.theme.primaryText : props.theme.p};
+  width: 100%;
+  cursor: pointer
+`
+
+const AccountRow: React.FC<Interface> = ({ account, selected, onClick }: Interface) =>
+  <DpathRowStyles onClick={onClick} selected={selected}>
+    {account.dPath}
+    :
+    {shortAddress(account.address)}
+    :
+    {account.balance}
+  </DpathRowStyles>
+
+export default AccountRow

--- a/src/ux/chooseDpath/AccountRow.tsx
+++ b/src/ux/chooseDpath/AccountRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import BN from 'bn.js'
+import BigNumber from 'bignumber.js'
 import { shortAddress } from '../confirmInformation/ConfirmInformation'
 import { AccountInterface } from './ChooseDPath'
 
@@ -26,23 +26,22 @@ const DpathRowStyles = styled.button<{ selected: boolean }>`
 `
 
 const Column = styled.div`
-  width: 33%;
+  width: ${(props: { width?: number }) => props.width ? `${props.width}%` : '33%'};
   text-align: left;
-  padding: 0 5px;
+  padding: 0 5px 0 10px;
 `
 
 const AccountRow: React.FC<Interface> = ({ account, selected, onClick, balancePrefix }: Interface) => {
-  const balance = account.balance && account.balance.startsWith('0x')
-    ? new BN(account.balance.substring(2), 16)
-    : new BN(account.balance || 0, 16)
-
-  // BN.js does not handle decimals
-  const niceBalance = balance.toNumber() / 1000000000000000000
+  const balance = new BigNumber(account.balance || 0)
+  const stringBalance = balance.div(new BigNumber(10).pow(18)).toString(10)
+  const niceBalance = stringBalance.substring(0, 11)
 
   return <DpathRowStyles onClick={onClick} selected={selected}>
     <Column>{account.dPath}</Column>
     <Column>{shortAddress(account.address)}</Column>
-    <Column>{`${niceBalance.toString().substring(0, 10)} ${balancePrefix}`} </Column>
+    <Column title={`${stringBalance} ${balancePrefix}`}>
+      {`${niceBalance} ${balancePrefix}`}
+    </Column>
   </DpathRowStyles>
 }
 

--- a/src/ux/chooseDpath/AccountRow.tsx
+++ b/src/ux/chooseDpath/AccountRow.tsx
@@ -31,7 +31,7 @@ const Column = styled.div`
   padding: 0 5px;
 `
 
-const AccountRow: React.FC<Interface> = ({ account, selected, onClick, balancePrefix}: Interface) => {
+const AccountRow: React.FC<Interface> = ({ account, selected, onClick, balancePrefix }: Interface) => {
   const balance = account.balance && account.balance.startsWith('0x')
     ? new BN(account.balance.substring(2), 16)
     : new BN(account.balance || 0, 16)

--- a/src/ux/chooseDpath/AccountRow.tsx
+++ b/src/ux/chooseDpath/AccountRow.tsx
@@ -8,6 +8,7 @@ interface Interface {
   account: AccountInterface
   onClick: () => void,
   selected: boolean
+  balancePrefix?: string
 }
 
 const DpathRowStyles = styled.button<{ selected: boolean }>`
@@ -30,7 +31,7 @@ const Column = styled.div`
   padding: 0 5px;
 `
 
-const AccountRow: React.FC<Interface> = ({ account, selected, onClick }: Interface) => {
+const AccountRow: React.FC<Interface> = ({ account, selected, onClick, balancePrefix}: Interface) => {
   const balance = account.balance && account.balance.startsWith('0x')
     ? new BN(account.balance.substring(2), 16)
     : new BN(account.balance || 0, 16)
@@ -41,7 +42,7 @@ const AccountRow: React.FC<Interface> = ({ account, selected, onClick }: Interfa
   return <DpathRowStyles onClick={onClick} selected={selected}>
     <Column>{account.dPath}</Column>
     <Column>{shortAddress(account.address)}</Column>
-    <Column>{niceBalance.toString().substring(0, 10)} RBTC</Column>
+    <Column>{`${niceBalance.toString().substring(0, 10)} ${balancePrefix}`} </Column>
   </DpathRowStyles>
 }
 

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -79,6 +79,15 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     .then(() => selectPath(provider.selectedAddress))
     .catch(handleError)
 
+  const getGasNameFromChain = (chainId: number) => {
+    switch (chainId) {
+      case 1: return 'ETH'
+      case 30: return 'RBTC'
+      case 31: return 'tRBTC'
+      default: return ''
+    }
+  }
+
   if (allAccounts.length === 0) {
     return <LoadingComponent text="retrieving addresses and balances" />
   }
@@ -98,6 +107,7 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
         account={account}
         selected={account.dPath === selectedAccount}
         onClick={() => setSelectedAccount(account.dPath)}
+        balancePrefix={getGasNameFromChain(provider.chainId)}
       />
     )}
 

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
-import { isLedger } from '../../lib/hardware-wallets'
 import { Header2, Paragraph } from '../../ui/shared/Typography'
 import LoadingComponent from '../../ui/shared/Loading'
 import { Button } from '../../ui/shared/Button'
 import AccountRow from './AccountRow'
+import { Trans } from 'react-i18next'
 
 export interface AccountInterface {
   index: number
@@ -127,13 +126,13 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
   }
 
   return <>
-    <Header2>Select an account</Header2>
+    <Header2><Trans>Select an account</Trans></Header2>
 
     <AccountWrapper>
       <Row>
-        <Column>Path</Column>
-        <Column>Address</Column>
-        <Column>Balance</Column>
+        <Column><Trans>Path</Trans></Column>
+        <Column><Trans>Address</Trans></Column>
+        <Column><Trans>Balance</Trans></Column>
       </Row>
 
       {viewableAccounts.map((account: AccountInterface) =>
@@ -160,7 +159,7 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     >&gt;</Button>
 
     <Paragraph>
-      Or use the textbox to choose a specific path:
+      <Trans>Or use the textbox to choose a specific path:</Trans>
       <DPathInput
         type="text"
         className="final-dpath"
@@ -170,8 +169,6 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
       />
     </Paragraph>
 
-    <Button onClick={handleSelectAccount} disabled={isLoading}>Select</Button>
+    <Button onClick={handleSelectAccount} disabled={isLoading}><Trans>Confirm</Trans></Button>
   </>
 }
-
-export const initialDPath = (selectedChainId: string, providerName: string) => getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)).slice(2)

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -38,8 +38,10 @@ const Row = styled.div`
 `
 
 export const Column = styled.div`
-  width: 33%;
-  text-align: left;
+  width: ${(props: { width?: number }) => props.width ? `${props.width}%` : '33%'};
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 0 5px 0 10px;
 `
 
@@ -110,12 +112,11 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     const newAccounts = allAccounts.filter((account) =>
       account.index >= newIndex && account.index < newIndex + 5)
 
-    setSelectedAccount(newAccounts[0].dPath)
-
     if (newAccounts.length === 0) {
       return getAccountsAndBalance(newIndex)
     }
 
+    setSelectedAccount(newAccounts[0].dPath)
     setViewAbleAccounts(newAccounts)
   }
 

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -5,6 +5,7 @@ import LoadingComponent from '../../ui/shared/Loading'
 import { Button } from '../../ui/shared/Button'
 import AccountRow from './AccountRow'
 import { Trans } from 'react-i18next'
+import { getGasNameFromChain } from '../../adapters'
 
 export interface AccountInterface {
   index: number
@@ -43,7 +44,7 @@ export const Column = styled.div`
 `
 
 interface Interface {
-  provider: any // RLoginEIP1193Provider
+  provider: any
   selectPath: (address: string) => void
   handleError: (error: any) => void
 }
@@ -79,19 +80,21 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
             params: [account.address.toLowerCase(), 'latest']
           }))
 
+        setSelectedAccount(accounts[0].dPath)
+
         // get the balances
         Promise.all(balanceRequests)
           .then((balances: string[]) => {
             const newAccounts = accounts.map((account, index) => (
               { ...account, balance: balances[index], index: index + startingIndex }
             ))
+
             setAllAccounts([...allAccounts, ...newAccounts])
             setViewAbleAccounts(newAccounts)
-            setSelectedAccount(newAccounts[0].dPath)
+            setIsLoading(false)
           })
       })
       .catch(handleError)
-      .finally(() => setIsLoading(false))
   }
 
   const handleSelectAccount = () => provider.chooseAccount(selectedAccount)
@@ -104,21 +107,13 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     const newAccounts = allAccounts.filter((account) =>
       account.index >= newIndex && account.index < newIndex + 5)
 
+    setSelectedAccount(newAccounts[0].dPath)
+
     if (newAccounts.length === 0) {
       return getAccountsAndBalance(newIndex)
     }
 
     setViewAbleAccounts(newAccounts)
-    setSelectedAccount(newAccounts[0].dPath)
-  }
-
-  const getGasNameFromChain = (chainId: number) => {
-    switch (chainId) {
-      case 1: return 'ETH'
-      case 30: return 'RBTC'
-      case 31: return 'tRBTC'
-      default: return ''
-    }
   }
 
   if (viewableAccounts.length === 0) {
@@ -165,7 +160,6 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
         className="final-dpath"
         value={selectedAccount}
         onChange={e => setSelectedAccount(e.target.value)}
-        disabled={isLoading}
       />
     </Paragraph>
 

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -72,17 +72,8 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
         ]))
   }, [provider])
 
-  const handleSelectAccount = () => {
-    const account = allAccounts.filter((account: AccountInterface) => account.dPath === selectedAccount)
-
-    if (account[0].address) {
-      return provider.chooseAccount(selectedAccount)
-        .then(() => selectPath(provider.selectedAddress))
-    }
-
-    console.log('no address, we need to find it ;-)')
-    // handle custom dpath, need to get the address...
-  }
+  const handleSelectAccount = () => provider.chooseAccount(selectedAccount)
+    .then(() => selectPath(provider.selectedAddress))
 
   if (allAccounts.length === 0) {
     return <LoadingComponent text="retrieving addresses" />

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -68,7 +68,6 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
 
   const getAccountsAndBalance = (startingIndex: number) => {
     setIsLoading(true)
-    setViewableIndex(startingIndex)
     setViewAbleAccounts([])
 
     const currentIndexes = Array.from({ length: 5 }, (_, i) => i + startingIndex)
@@ -89,6 +88,7 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
             ))
             setAllAccounts([...allAccounts, ...newAccounts])
             setViewAbleAccounts(newAccounts)
+            setSelectedAccount(newAccounts[0].dPath)
           })
       })
       .catch(handleError)
@@ -105,7 +105,12 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     const newAccounts = allAccounts.filter((account) =>
       account.index >= newIndex && account.index < newIndex + 5)
 
-    return (newAccounts.length === 0) ? getAccountsAndBalance(newIndex) : setViewAbleAccounts(newAccounts)
+    if (newAccounts.length === 0) {
+      return getAccountsAndBalance(newIndex)
+    }
+
+    setViewAbleAccounts(newAccounts)
+    setSelectedAccount(newAccounts[0].dPath)
   }
 
   const getGasNameFromChain = (chainId: number) => {

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 import { isLedger } from '../../lib/hardware-wallets'
-import { WideBox } from '../../ui/shared/Box'
-import { Paragraph } from '../../ui/shared/Typography'
+import { Header2, Header3, Paragraph } from '../../ui/shared/Typography'
 import LoadingComponent from '../../ui/shared/Loading'
 import { Button } from '../../ui/shared/Button'
 import AccountRow from './AccountRow'
@@ -23,6 +22,20 @@ const DPathInput = styled.input`
   &:focus {
     outline: none;
 }
+`
+
+const Row = styled.div`
+  display: flex;
+  font-size: 14px;
+  color: ${props => props.theme.h3};
+  border-bottom: ${(props) => `1px solid ${props.theme.p}`};
+  padding-bottom: 5px;
+`
+
+export const Column = styled.div`
+  width: 33%;
+  text-align: left;
+  padding: 0 5px 0 10px;
 `
 
 interface Interface {
@@ -45,7 +58,10 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     provider.getAddresses(accountIds)
       .then((accounts: AccountInterface[]) => {
         const balanceRequests = accountIds.map((id) =>
-          provider.request({ method: 'eth_getBalance', params: [accounts[id].address, 'latest'] }))
+          provider.request({
+            method: 'eth_getBalance',
+            params: [accounts[id].address.toLowerCase(), 'latest']
+          }))
 
         // get the balances
         Promise.all(balanceRequests)
@@ -54,8 +70,7 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
               // add balances to the account objects
               accountIds.map((id: number) => (
                 { ...accounts[id], balance: balances[id] }
-              )))
-          )
+              ))))
       })
       .catch(handleError)
   }, [provider])
@@ -65,22 +80,17 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     .catch(handleError)
 
   if (allAccounts.length === 0) {
-    return <LoadingComponent text="retrieving addresses" />
+    return <LoadingComponent text="retrieving addresses and balances" />
   }
 
-  return <WideBox>
-    <Paragraph>Using:
-      <DPathInput
-        type="text"
-        className="final-dpath"
-        value={selectedAccount}
-        onChange={e => setSelectedAccount(e.target.value)}
-      />
-    </Paragraph>
+  return <>
+    <Header2>Select an account</Header2>
 
-    <Paragraph>
-      Standard base derivation path: {provider.path}
-    </Paragraph>
+    <Row>
+      <Column>Path</Column>
+      <Column>Address</Column>
+      <Column>Balance</Column>
+    </Row>
 
     {allAccounts.map((account: AccountInterface) =>
       <AccountRow
@@ -90,8 +100,19 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
         onClick={() => setSelectedAccount(account.dPath)}
       />
     )}
+
+    <Header3>Or choose a specific path</Header3>
+    <Paragraph>Current Path:
+      <DPathInput
+        type="text"
+        className="final-dpath"
+        value={selectedAccount}
+        onChange={e => setSelectedAccount(e.target.value)}
+      />
+    </Paragraph>
+
     <Button onClick={handleSelectAccount}>Select</Button>
-  </WideBox>
+  </>
 }
 
 export const initialDPath = (selectedChainId: string, providerName: string) => getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)).slice(2)

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -97,9 +97,12 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
       .catch(handleError)
   }
 
-  const handleSelectAccount = () => provider.chooseAccount(selectedAccount)
-    .then(() => selectPath(provider.selectedAddress))
-    .catch(handleError)
+  const handleSelectAccount = () => {
+    setIsLoading(true)
+    provider.chooseAccount(selectedAccount)
+      .then(() => selectPath(provider.selectedAddress))
+      .catch(handleError)
+  }
 
   const showMoreAccounts = (newIndex: number) => {
     setViewableIndex(newIndex)

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -50,11 +50,13 @@ const DpathRow = ({ account, selected, onClick }: DpathRowInterface) =>
 interface Interface {
   provider: any // RLoginEIP1193Provider
   selectPath: (address: string) => void
+  handleError: (error: any) => void
 }
 
 export const ChooseDPathComponent: React.FC<Interface> = ({
   provider,
-  selectPath
+  selectPath,
+  handleError
 }) => {
   const [allAccounts, setAllAccounts] = useState<AccountInterface[]>([])
   const [selectedAccount, setSelectedAccount] = useState<string>(provider.path)
@@ -70,10 +72,12 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
           },
           ...result
         ]))
+      .catch(handleError)
   }, [provider])
 
   const handleSelectAccount = () => provider.chooseAccount(selectedAccount)
     .then(() => selectPath(provider.selectedAddress))
+    .catch(handleError)
 
   if (allAccounts.length === 0) {
     return <LoadingComponent text="retrieving addresses" />

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -49,7 +49,7 @@ const DpathRow = ({ account, selected, onClick }: DpathRowInterface) =>
 
 interface Interface {
   provider: any // RLoginEIP1193Provider
-  selectPath: (accountAndPath: AccountInterface) => void
+  selectPath: (address: string) => void
 }
 
 export const ChooseDPathComponent: React.FC<Interface> = ({
@@ -77,7 +77,7 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
 
     if (account[0].address) {
       return provider.chooseAccount(selectedAccount)
-        .then(() => selectPath(account[0]))
+        .then(() => selectPath(provider.selectedAddress))
     }
 
     console.log('no address, we need to find it ;-)')

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
-import { isLedger } from '../lib/hardware-wallets'
-import { WideBox } from '../ui/shared/Box'
-import { Paragraph } from '../ui/shared/Typography'
+import { isLedger } from '../../lib/hardware-wallets'
+import { WideBox } from '../../ui/shared/Box'
+import { Paragraph } from '../../ui/shared/Typography'
+import LoadingComponent from '../../ui/shared/Loading'
 
 interface DpathRowInterface {
-  i: number,
-  dpath: string,
+  path: {
+    path: string,
+    address: string
+  }
   onClick: () => void,
   selected: boolean
 }
@@ -35,15 +38,31 @@ const DPathInput = styled.input`
 }
 `
 
-const DpathRow = ({ i, dpath, selected, onClick }: DpathRowInterface) =>
+const DpathRow = ({ path, selected, onClick }: DpathRowInterface) =>
   <DpathRowStyles onClick={onClick} selected={selected}>
-    Account {i} : {dpath}
+    {path.path} : {path.address}
   </DpathRowStyles>
 
-export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: { dPath: string, setDPath: (dPpath: string) => void, providerName: string, selectedChainId: string }) => {
-  const [customDpathIndex, setCustomDpathIndex] = useState(5)
-  const customDpathPath = getDPathByChainId(parseInt(selectedChainId), customDpathIndex || 0, isLedger(providerName))
+interface Interface {
+  provider: any // RLoginEIP1193Provider
+}
 
+// export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: { dPath: string, setDPath: (dPpath: string) => void, providerName: string, selectedChainId: string }) => {
+export const ChooseDPathComponent: React.FC<Interface> = ({
+  provider
+}) => {
+  const [dPath, setDPath] = useState<string>('')
+  const [allPaths, setAllPaths] = useState<any[]>([])
+
+  useEffect(() => {
+    console.log('provider', provider)
+    setDPath(provider.dpath)
+    console.log('getting others...')
+    provider.getAddresses([1, 2, 3, 4, 50]).then((result: any) => setAllPaths(result))
+  }, [provider])
+  // const [customDpathIndex, setCustomDpathIndex] = useState(5)
+  // const customDpathPath = getDPathByChainId(parseInt(selectedChainId), customDpathIndex || 0, isLedger(providerName))
+  /*
   useEffect(() => {
     setDPath(getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)))
   }, [selectedChainId])
@@ -52,6 +71,10 @@ export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: 
     const customPath = parseInt(e.target.value)
     setCustomDpathIndex(customPath)
     customPath !== 0 && setDPath(getDPathByChainId(customPath, 0, isLedger(providerName)))
+  }
+  */
+  if (allPaths.length === 0) {
+    return <LoadingComponent text="retrieving addresses" />
   }
 
   return <WideBox>
@@ -65,34 +88,12 @@ export const ChooseDPath = ({ dPath, setDPath, providerName, selectedChainId }: 
     </Paragraph>
 
     <Paragraph>
-      Standard base derivation path: {getDPathByChainId(parseInt(selectedChainId), 0, isLedger(providerName)).slice(0, -1)}
+      Standard base derivation path:
     </Paragraph>
-    {Array.from({ length: 4 }, (_, i) => {
-      const dpath = getDPathByChainId(parseInt(selectedChainId), i, isLedger(providerName))
-      return <DpathRow
-        key={i}
-        i={i}
-        dpath={dpath}
-        onClick={() => setDPath(dpath)}
-        selected={dpath === dPath}
-      />
-    })}
 
-    <Paragraph>
-      Custom Account:
-      <DPathInput
-        type="number"
-        className="dpath-custom-index"
-        value={customDpathIndex}
-        onChange={handleCustomChange}
-      />
-      <DpathRow
-        i={customDpathIndex || 0}
-        dpath={customDpathPath}
-        onClick={() => setDPath(customDpathPath)}
-        selected={customDpathPath === dPath}
-      />
-    </Paragraph>
+    {allPaths.map((path: any) =>
+      <DpathRow key={path.path} path={path} selected={false} onClick={() => console.log('click')} />
+    )}
   </WideBox>
 }
 

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -2,38 +2,33 @@
 import React, { useState } from 'react'
 import { Trans } from 'react-i18next'
 
-import { Header2, SmallSpan } from '../../ui/shared/Typography'
+import { Header2 } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
 import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
-import Checkbox from '../../ui/shared/Checkbox'
-import { ChooseDPath, initialDPath } from '../ChooseDPath'
-import { isHardwareWalletProvider } from '../../lib/hardware-wallets'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
   networkParamsOptions?: NetworkParamsAllOptions
-  chooseNetwork: (network: { chainId: number, rpcUrl?: string, dPath?: string, networkParams?:NetworkParams }) => void
-  providerName: string
+  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }) => void
 }
 
 const ChooseNetworkComponent: React.FC<Interface> = ({
   rpcUrls,
   networkParamsOptions,
-  chooseNetwork,
-  providerName
+  chooseNetwork
 }) => {
   if (!rpcUrls) {
     return <></>
   }
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
 
-  const [dpathEnabled, setDpathEnabled] = useState(false)
-  const [dPath, setDPath] = useState(initialDPath(selectedChainId, providerName))
+  // const [dpathEnabled, setDpathEnabled] = useState(false)
+  // const [dPath, setDPath] = useState(initialDPath(selectedChainId, providerName))
 
   const handleSelect = () =>
-    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], dPath: !dpathEnabled ? undefined : dPath, networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
+    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
 
   return (
     <div>
@@ -45,13 +40,6 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
           )}
         </Select>
       </p>
-      {isHardwareWalletProvider(providerName) && <>
-        <label>
-          <Checkbox checked={dpathEnabled} onChange={() => setDpathEnabled(!dpathEnabled)} />
-          <SmallSpan><Trans>Change derivation path</Trans></SmallSpan>
-        </label>
-        {dpathEnabled && <ChooseDPath {...{ dPath, setDPath, providerName, selectedChainId }} />}
-      </>}
       <p>
         <Button onClick={handleSelect}>Choose</Button>
       </p>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -2,35 +2,30 @@
 import React, { useState } from 'react'
 import { Trans } from 'react-i18next'
 
-import { Header2, SmallSpan } from '../../ui/shared/Typography'
+import { Header2 } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
 import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
-import { isHardwareWalletProvider } from '../../lib/hardware-wallets'
-import Checkbox from '../../ui/shared/Checkbox'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
   networkParamsOptions?: NetworkParamsAllOptions
-  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }, configureDPath: boolean) => void,
-  providerName: string
+  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }) => void,
 }
 
 const ChooseNetworkComponent: React.FC<Interface> = ({
   rpcUrls,
   networkParamsOptions,
-  chooseNetwork,
-  providerName
+  chooseNetwork
 }) => {
   if (!rpcUrls) {
     return <></>
   }
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
-  const [dpathEnabled, setDpathEnabled] = useState(false)
 
   const handleSelect = () =>
-    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) }, dpathEnabled)
+    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
 
   return (
     <div>
@@ -42,13 +37,6 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
           )}
         </Select>
       </p>
-      {isHardwareWalletProvider(providerName) && <>
-        <label>
-          <Checkbox checked={dpathEnabled} onChange={() => setDpathEnabled(!dpathEnabled)} />
-          <SmallSpan><Trans>Change derivation path</Trans></SmallSpan>
-        </label>
-      </>
-      }
       <p>
         <Button onClick={handleSelect}>Choose</Button>
       </p>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -2,33 +2,35 @@
 import React, { useState } from 'react'
 import { Trans } from 'react-i18next'
 
-import { Header2 } from '../../ui/shared/Typography'
+import { Header2, SmallSpan } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
 import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
+import { isHardwareWalletProvider } from '../../lib/hardware-wallets'
+import Checkbox from '../../ui/shared/Checkbox'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
   networkParamsOptions?: NetworkParamsAllOptions
-  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }) => void
+  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }, configureDPath: boolean) => void,
+  providerName: string
 }
 
 const ChooseNetworkComponent: React.FC<Interface> = ({
   rpcUrls,
   networkParamsOptions,
-  chooseNetwork
+  chooseNetwork,
+  providerName
 }) => {
   if (!rpcUrls) {
     return <></>
   }
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
-
-  // const [dpathEnabled, setDpathEnabled] = useState(false)
-  // const [dPath, setDPath] = useState(initialDPath(selectedChainId, providerName))
+  const [dpathEnabled, setDpathEnabled] = useState(false)
 
   const handleSelect = () =>
-    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
+    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) }, dpathEnabled)
 
   return (
     <div>
@@ -40,6 +42,13 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
           )}
         </Select>
       </p>
+      {isHardwareWalletProvider(providerName) && <>
+        <label>
+          <Checkbox checked={dpathEnabled} onChange={() => setDpathEnabled(!dpathEnabled)} />
+          <SmallSpan><Trans>Change derivation path</Trans></SmallSpan>
+        </label>
+      </>
+      }
       <p>
         <Button onClick={handleSelect}>Choose</Button>
       </p>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -23,22 +23,25 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
     return <></>
   }
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
+  const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  const handleSelect = () =>
+  const handleSelect = () => {
+    setIsLoading(true)
     chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
+  }
 
   return (
     <div>
       <Header2><Trans>Choose Network</Trans></Header2>
       <p>
-        <Select value={selectedChainId} onChange={evt => setSelectedChainId(evt.target.value)}>
+        <Select disabled={isLoading} value={selectedChainId} onChange={evt => setSelectedChainId(evt.target.value)}>
           {Object.keys(rpcUrls).map((chainId: string) =>
             <option key={chainId} value={chainId}>{getChainName(parseInt(chainId))}</option>
           )}
         </Select>
       </p>
       <p>
-        <Button onClick={handleSelect}>Choose</Button>
+        <Button disabled={isLoading} onClick={handleSelect}>Choose</Button>
       </p>
     </div>
   )

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -174,7 +174,7 @@ const LogoWrapper = styled.div`
   }
 `
 
-function shortAddress (address?: string): string {
+export function shortAddress (address?: string): string {
   if (!address) return ''
 
   return `${address.substr(0, 6)}...${address.substr(


### PR DESCRIPTION
This uses the existing 'Choose Network' screen before connecting, but then if the wallet isLedger or isTrezor, it will prompt the user to select an account/dpath.

## features

- Shows five accounts at a time and saves the loaded ones in memory. 
- Shows balance of those accounts using bignumber.js which was already a dependency.
- The provider is now responsible for the selected dPath, not rLogin
- Connects to the device to get the next set of accounts
- Disables 'select' button when choosing a network. Closes #205

## misc changes

- do not send Cypress results externally. We are out of credits and this was causing the build to fail 

## provider changes

Changes in the providers is in [this PR](https://github.com/rsksmart/rLogin-providers/pull/42). It is currently pending the Trezor integration. See that PR for description of the changes.

- [x] Ledger new methods
- [x] Trezor new methods

D'Cent wallet will not be considered in this PR. 

## next steps

- [ ] Merge and deploy beta versions of https://github.com/rsksmart/rLogin-providers/pull/42
- [ ] Merge and deploy beta version of this

## visual

![Screen Shot 2022-01-18 at 2 55 48 PM](https://user-images.githubusercontent.com/766679/149941617-b6937fae-2e55-4ae9-b1da-3004a40e2126.png)
