### PR TITLE
Hide providers if they are disabled

### DIFF
--- a/src/constants/cssSelectors.ts
+++ b/src/constants/cssSelectors.ts
@@ -21,6 +21,10 @@ export const PROVIDER_CONTAINER_DISABLED_CLASSNAME = 'rlogin-provider-disabled-c
 export const PROVIDER_ICON_CLASSNAME = 'rlogin-provider-icon'
 export const PROVIDERS_FOOTER_TEXT_CLASSNAME = 'rlogin-footer-text'
 export const PROVIDERS_DEVELOPER_CLASSNAME = 'rlogin-developer-providers'
+export const PROVIDERS_INJECTED = 'rlogin-providers-injected'
+export const PROVIDERS_MOBILE = 'rlogin-providers-mobile'
+export const PROVIDERS_CUSTODIAL = 'rlogin-providers-custodial'
+export const PROVIDERS_HARDWARE = 'rlogin-providers-hardware'
 
 // Typography
 export const HEADER2_CLASS = 'rlogin-header2'

--- a/src/ux/step1/Provider.test.tsx
+++ b/src/ux/step1/Provider.test.tsx
@@ -5,12 +5,15 @@ import { PROVIDER_CONTAINER_CLASSNAME } from '../../constants/cssSelectors'
 
 describe('Component: Provider', () => {
   const props = {
-    name: 'Test Provider',
-    logo: 'image.jpg',
-    description: 'A provider',
-    onClick: jest.fn(),
-    disabled: false,
-    width: '100%'
+    userProvider: {
+      name: 'Test Provider',
+      logo: 'image.jpg',
+      description: 'A provider',
+      onClick: jest.fn()
+    },
+    handleConnect: jest.fn(),
+    width: '100%',
+    hideIfDisabled: false
   }
 
   it('renders and is defined', () => {
@@ -33,12 +36,27 @@ describe('Component: Provider', () => {
     expect(onClick).toBeCalledTimes(1)
   })
 
-  it('if is disabled should not be fire onClick event', () => {
-    const onClick = jest.fn()
-    const localProps = { ...props, disabled: true, onClick }
-    const wrapper = mount(<Provider {...localProps} />)
+  describe('hideIfDisabled', () => {
+    const localProps = {
+      ...props,
+      userProvider: {
+        name: 'Test Provider',
+        logo: 'image.jpg',
+        description: 'A provider'
+      }
+    }
 
-    wrapper.find(`div.${PROVIDER_CONTAINER_CLASSNAME}`).simulate('click')
-    expect(onClick).toBeCalledTimes(0)
+    it('it will show when set to false', () => {
+      const wrapper = mount(<Provider {...localProps} hideIfDisabled={false} />)
+
+      expect(wrapper.find(`div.${PROVIDER_CONTAINER_CLASSNAME}`).text()).toBe('Test Provider')
+      expect(wrapper.find(`div.${PROVIDER_CONTAINER_CLASSNAME}`).props().disabled).toBeTruthy()
+    })
+
+    it('it will hide when set to true', () => {
+      const wrapper = mount(<Provider {...localProps} hideIfDisabled={true} />)
+
+      expect(wrapper.find(`div.${PROVIDER_CONTAINER_CLASSNAME}`)).toMatchObject({})
+    })
   })
 })

--- a/src/ux/step1/Provider.tsx
+++ b/src/ux/step1/Provider.tsx
@@ -84,7 +84,10 @@ export function Provider (props: IProviderProps) {
 
   return (hideIfDisabled && disabled) ? <></> : (
     <ProviderContainer disabled={disabled}>
-      <ProviderBox disabled={disabled} className={`${PROVIDER_CONTAINER_CLASSNAME} ${disabled && PROVIDER_CONTAINER_DISABLED_CLASSNAME}`} onClick={userProvider.onClick || undefined} {...otherProps}>
+      <ProviderBox
+        disabled={disabled}
+        className={`${PROVIDER_CONTAINER_CLASSNAME} ${disabled && PROVIDER_CONTAINER_DISABLED_CLASSNAME}`}
+        onClick={disabled ? undefined : () => handleConnect(userProvider)} {...otherProps}>
         <HeaderRow>
           <ProviderIcon className={PROVIDER_ICON_CLASSNAME}>
             <img src={userProvider.logo} alt={userProvider.name} />

--- a/src/ux/step1/Provider.tsx
+++ b/src/ux/step1/Provider.tsx
@@ -63,30 +63,33 @@ const HeaderRow = styled.div`
 `
 
 interface IProviderProps {
-  name: string;
-  logo: string;
-  description: string;
-  onClick: () => void;
-  disabled?: boolean;
+  userProvider: {
+    name: string;
+    logo: string;
+    description: string;
+    onClick?: () => Promise<void>;
+  },
+  handleConnect: (provider: any) => void
+  hideIfDisabled: boolean
 }
 
 export function Provider (props: IProviderProps) {
   const {
-    name,
-    logo,
-    description,
-    onClick,
-    disabled = true,
+    userProvider,
+    handleConnect,
+    hideIfDisabled,
     ...otherProps
   } = props
-  return (
+  const disabled = !userProvider.onClick
+
+  return (hideIfDisabled && disabled) ? <></> : (
     <ProviderContainer disabled={disabled}>
-      <ProviderBox disabled={disabled} className={`${PROVIDER_CONTAINER_CLASSNAME} ${disabled && PROVIDER_CONTAINER_DISABLED_CLASSNAME}`} onClick={disabled ? undefined : onClick} {...otherProps}>
+      <ProviderBox disabled={disabled} className={`${PROVIDER_CONTAINER_CLASSNAME} ${disabled && PROVIDER_CONTAINER_DISABLED_CLASSNAME}`} onClick={userProvider.onClick || undefined} {...otherProps}>
         <HeaderRow>
           <ProviderIcon className={PROVIDER_ICON_CLASSNAME}>
-            <img src={logo} alt={name} />
+            <img src={userProvider.logo} alt={userProvider.name} />
           </ProviderIcon>
-          <Header3>{name}</Header3>
+          <Header3>{userProvider.name}</Header3>
         </HeaderRow>
       </ProviderBox>
     </ProviderContainer>

--- a/src/ux/step1/WalletProviders.test.tsx
+++ b/src/ux/step1/WalletProviders.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { WalletProviders } from './WalletProviders'
-import { PROVIDERS_FOOTER_TEXT_CLASSNAME, PROVIDERS_DEVELOPER_CLASSNAME } from '../../constants/cssSelectors'
+import { PROVIDERS_FOOTER_TEXT_CLASSNAME, PROVIDERS_DEVELOPER_CLASSNAME, PROVIDERS_HARDWARE } from '../../constants/cssSelectors'
 import { themesOptions } from '../../theme'
 
 describe('Component: WalletProviders', () => {
@@ -55,5 +55,20 @@ describe('Component: WalletProviders', () => {
   it('does not show language selector when only one language available', () => {
     const wrapper = mount(<WalletProviders {...propsWithOneLanguage} userProviders={[]} />)
     expect(wrapper.find('select').children()).toHaveLength(0)
+  })
+
+  it('shows/hides providers when they are disabled', () => {
+    const providerProps = { logo: 'test1.jpg', description: 'description1', onClick: jest.fn() }
+    const userProviders = [
+      { ...providerProps, name: 'Tally' },
+      { ...providerProps, name: 'Wallet Connect' }
+    ]
+
+    const wrapper = mount(<WalletProviders {...props} userProviders={userProviders} />)
+    const children = wrapper.find(`.${PROVIDERS_HARDWARE}`).children()
+
+    expect(children.first()).toMatchObject({})
+    expect(children.at(2)).toMatchObject({})
+    expect(children.at(3)).toMatchObject({})
   })
 })

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import styled, { css } from 'styled-components'
 import { Provider } from './Provider'
 import { IProviderUserOptions, providers } from 'web3modal'
@@ -44,8 +44,14 @@ const ProviderRow = styled.div<{ hideMobile?: boolean }>`
   }
 `
 
-const UserProvider = ({ userProvider, handleConnect }: { userProvider: IProviderUserOptions, handleConnect: (provider: any) => void }) =>
-  <Provider
+interface UserProviderInterface {
+  userProvider: IProviderUserOptions,
+  handleConnect: (provider: any) => void
+  hideIfDisabled: boolean
+}
+
+const UserProvider = ({ userProvider, handleConnect, hideIfDisabled }: UserProviderInterface) =>
+  (!userProvider.onClick && hideIfDisabled) ? <></> : <Provider
     key={userProvider.name}
     name={userProvider.name}
     logo={userProvider.logo}
@@ -63,6 +69,8 @@ export const userProvidersByName = (userProviders: IProviderUserOptions[]) => {
 }
 
 export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage, changeTheme, availableLanguages, selectedLanguageCode, selectedTheme }: IWalletProvidersProps) => {
+  const [providersByName, setProvidersByName] = useState(userProvidersByName(userProviders))
+
   // the providers that are hardcoded into the layout below
   const hardCodedProviderNames = [
     providers.METAMASK.name, providers.NIFTY.name, providers.LIQUALITY.name, TALLYWALLET.name, // browser
@@ -71,7 +79,10 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
     LEDGER.name, TREZOR.name, DCENT.name // hardware
   ]
 
-  const providersByName = userProvidersByName(userProviders)
+  // Handle a update in the userProviders after the state has loaded.
+  useEffect(() => {
+    setProvidersByName(userProvidersByName(userProviders))
+  }, [userProviders])
 
   // additional providers that the developer wants to use
   const developerProviders = Object.keys(providersByName).filter((providerName: string) =>
@@ -86,22 +97,22 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
     </Header2>
     <ProvidersWrapper className={PROVIDERS_WRAPPER_CLASSNAME}>
       <ProviderRow>
-        <UserProvider userProvider={providersByName[providers.METAMASK.name] || providers.METAMASK} handleConnect={handleConnect} />
-        <UserProvider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} />
-        <UserProvider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} />
-        <UserProvider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} />
+        <UserProvider userProvider={providersByName[providers.METAMASK.name] || providers.METAMASK} handleConnect={handleConnect} hideIfDisabled={false} />
+        <UserProvider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} hideIfDisabled={false} />
+        <UserProvider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={false} />
+        <UserProvider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
       <ProviderRow hideMobile={true}>
-        <UserProvider userProvider={providersByName[providers.WALLETCONNECT.name] || providers.WALLETCONNECT} handleConnect={handleConnect} />
+        <UserProvider userProvider={providersByName[providers.WALLETCONNECT.name] || providers.WALLETCONNECT} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
       <ProviderRow>
-        <UserProvider userProvider={providersByName[providers.PORTIS.name] || providers.PORTIS} handleConnect={handleConnect} />
-        <UserProvider userProvider={providersByName[providers.TORUS.name] || providers.TORUS} handleConnect={handleConnect} />
+        <UserProvider userProvider={providersByName[providers.PORTIS.name] || providers.PORTIS} handleConnect={handleConnect} hideIfDisabled={true} />
+        <UserProvider userProvider={providersByName[providers.TORUS.name] || providers.TORUS} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
       <ProviderRow hideMobile={true}>
-        <UserProvider userProvider={providersByName[LEDGER.name] || LEDGER} handleConnect={handleConnect} />
-        <UserProvider userProvider={providersByName[TREZOR.name] || TREZOR} handleConnect={handleConnect} />
-        <UserProvider userProvider={providersByName[DCENT.name] || DCENT} handleConnect={handleConnect} />
+        <UserProvider userProvider={providersByName[LEDGER.name] || LEDGER} handleConnect={handleConnect} hideIfDisabled={true} />
+        <UserProvider userProvider={providersByName[TREZOR.name] || TREZOR} handleConnect={handleConnect} hideIfDisabled={true} />
+        <UserProvider userProvider={providersByName[DCENT.name] || DCENT} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
       {developerProviders.length !== 0 && (
         <ProviderRow className={PROVIDERS_DEVELOPER_CLASSNAME}>
@@ -109,7 +120,8 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
             <UserProvider
               key={providerName}
               userProvider={providersByName[providerName]}
-              handleConnect={handleConnect} />
+              handleConnect={handleConnect}
+              hideIfDisabled={false} />
           )}
         </ProviderRow>
       )}

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components'
 import { Provider } from './Provider'
 import { IProviderUserOptions, providers } from 'web3modal'
 import { Header2 } from '../../ui/shared/Typography'
-import { PROVIDERS_WRAPPER_CLASSNAME, PROVIDERS_DEVELOPER_CLASSNAME } from '../../constants/cssSelectors'
+import { PROVIDERS_WRAPPER_CLASSNAME, PROVIDERS_DEVELOPER_CLASSNAME, PROVIDERS_CUSTODIAL, PROVIDERS_HARDWARE, PROVIDERS_INJECTED, PROVIDERS_MOBILE } from '../../constants/cssSelectors'
 import { Trans } from 'react-i18next'
 import { themesOptions } from '../../theme'
 
@@ -44,22 +44,6 @@ const ProviderRow = styled.div<{ hideMobile?: boolean }>`
   }
 `
 
-interface UserProviderInterface {
-  userProvider: IProviderUserOptions,
-  handleConnect: (provider: any) => void
-  hideIfDisabled: boolean
-}
-
-const UserProvider = ({ userProvider, handleConnect, hideIfDisabled }: UserProviderInterface) =>
-  (!userProvider.onClick && hideIfDisabled) ? <></> : <Provider
-    key={userProvider.name}
-    name={userProvider.name}
-    logo={userProvider.logo}
-    description=""
-    disabled={!userProvider.onClick}
-    onClick={() => handleConnect(userProvider)}
-  />
-
 export const userProvidersByName = (userProviders: IProviderUserOptions[]) => {
   const providersByName: { [name: string]: IProviderUserOptions } = {}
   for (const userProvider of userProviders) {
@@ -96,28 +80,28 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
       {Object.keys(userProviders).length !== 0 ? <Trans>Connect your wallet</Trans> : <Trans>No wallets found</Trans>}
     </Header2>
     <ProvidersWrapper className={PROVIDERS_WRAPPER_CLASSNAME}>
-      <ProviderRow>
-        <UserProvider userProvider={providersByName[providers.METAMASK.name] || providers.METAMASK} handleConnect={handleConnect} hideIfDisabled={false} />
-        <UserProvider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} hideIfDisabled={false} />
-        <UserProvider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={false} />
-        <UserProvider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
+      <ProviderRow className={PROVIDERS_INJECTED}>
+        <Provider userProvider={providersByName[providers.METAMASK.name] || providers.METAMASK} handleConnect={handleConnect} hideIfDisabled={false} />
+        <Provider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} hideIfDisabled={false} />
+        <Provider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={false} />
+        <Provider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
-      <ProviderRow hideMobile={true}>
-        <UserProvider userProvider={providersByName[providers.WALLETCONNECT.name] || providers.WALLETCONNECT} handleConnect={handleConnect} hideIfDisabled={true} />
+      <ProviderRow className={PROVIDERS_MOBILE} hideMobile={true}>
+        <Provider userProvider={providersByName[providers.WALLETCONNECT.name] || providers.WALLETCONNECT} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
-      <ProviderRow>
-        <UserProvider userProvider={providersByName[providers.PORTIS.name] || providers.PORTIS} handleConnect={handleConnect} hideIfDisabled={true} />
-        <UserProvider userProvider={providersByName[providers.TORUS.name] || providers.TORUS} handleConnect={handleConnect} hideIfDisabled={true} />
+      <ProviderRow className={PROVIDERS_CUSTODIAL}>
+        <Provider userProvider={providersByName[providers.PORTIS.name] || providers.PORTIS} handleConnect={handleConnect} hideIfDisabled={true} />
+        <Provider userProvider={providersByName[providers.TORUS.name] || providers.TORUS} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
-      <ProviderRow hideMobile={true}>
-        <UserProvider userProvider={providersByName[LEDGER.name] || LEDGER} handleConnect={handleConnect} hideIfDisabled={true} />
-        <UserProvider userProvider={providersByName[TREZOR.name] || TREZOR} handleConnect={handleConnect} hideIfDisabled={true} />
-        <UserProvider userProvider={providersByName[DCENT.name] || DCENT} handleConnect={handleConnect} hideIfDisabled={true} />
+      <ProviderRow className={PROVIDERS_HARDWARE} hideMobile={true}>
+        <Provider userProvider={providersByName[LEDGER.name] || LEDGER} handleConnect={handleConnect} hideIfDisabled={true} />
+        <Provider userProvider={providersByName[TREZOR.name] || TREZOR} handleConnect={handleConnect} hideIfDisabled={true} />
+        <Provider userProvider={providersByName[DCENT.name] || DCENT} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
       {developerProviders.length !== 0 && (
         <ProviderRow className={PROVIDERS_DEVELOPER_CLASSNAME}>
           {developerProviders.map((providerName: string) =>
-            <UserProvider
+            <Provider
               key={providerName}
               userProvider={providersByName[providerName]}
               handleConnect={handleConnect}


### PR DESCRIPTION
## Description

- Adds a new flag `hideIfDisabled` to each `<Provider` and will hide them if `true`.
- Removes `UserProvider` component as it was a unnecessary middleman to `<Provider`
   - Refactored `<Provider` to take a single `userProvider` variable that may or maynot contain `onClick`

## Screenshots 

Example of Tally and Wallet Connect

![Screen Shot 2022-02-02 at 1 17 49 PM](https://user-images.githubusercontent.com/766679/152143952-b999a2c3-5b7e-4563-abd4-095f22f09024.png)

Showing everything but with Metamask as the injected provider

![Screen Shot 2022-02-02 at 1 18 41 PM](https://user-images.githubusercontent.com/766679/152144079-27effec8-09e5-4289-8708-ffbad2b47ebd.png)


## How to test

The best way to smoke test would be to comment out different providers

