### PR TITLE
Allow user to select Ethereum Path when connecting to RSK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.3.0",
+  "version": "1.3.1-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rlogin",
-      "version": "1.3.0",
+      "version": "1.3.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.3.1-beta.2",
+  "version": "1.3.1-beta.3",
   "description": "Login tool for RSK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -101,7 +101,7 @@
             options: {
               bridge: "https://walletconnect-bridge.rifos.org/",
               rpc: {
-                1: 'https://mainnet.infura.io/v3/8043bb2cf99347b1bfadfb233c5325c0',
+                1: 'https://mainnet.infura.io/v3/7d5d71df32d548249ff444f6a43b43c5',
                 30: 'https://public-node.rsk.co',
                 31: 'https://public-node.testnet.rsk.co',
               }

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -56,8 +56,8 @@
     <script src="https://unpkg.com/@toruslabs/torus-embed@1.13.4/dist/torus.umd.min.js" integrity="sha256-PYFNxx1jq9Yra6tv1R5bB+VBP3lxSQG+aGie+UcVYro=" crossorigin="anonymous"></script>
 
     <!-- Hardware -->
-    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.2-beta.3/dist/bundle.js" integrity="sha384-mD7EobztXceQUROLOeYJS36lqvRZbfGDg1tdcBYX9YY0dN0yqt1CtoQZLRS5PJUv" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@rsksmart/rlogin-trezor-provider@1.0.2-beta.3/dist/bundle.js" integrity="sha384-FSSAPsXg4nmFYE/Mel1CC06UBlkzpzIPGUkKiPKeQTCv7po35OvCgUE44AVRTH3i" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-ledger-provider@1.0.2-beta.4/dist/bundle.js" integrity="sha384-gxC6iKOjbJMGCv4+5MNYfCIS9Q+Hf0LS+JycKicAowCwjjcKwQZJANf1LtHqBTkZ" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-trezor-provider@1.0.2-beta.4/dist/bundle.js" integrity="sha384-7ojkh5qXaTjb1bfdIDx5WEsWdWSftwfNS1OzciVj3vMpFjMY6NBSINzl20S0ri9O" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/@rsksmart/rlogin-dcent-provider@1.0.0-beta.8/dist/bundle.js" integrity="sha384-Zt1JFaeCbx2cs8Cu7N/4gYXPBB33TlqZoJlqboFo+vJuerwJcOGWzm2Xd8lpOWG2" crossorigin="anonymous"></script>
 
     <!-- RIF Data Vault Client -->

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -510,6 +510,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         {['wrongNetwork', 'changeNetwork'].includes(currentStep) && <WrongNetworkComponent chainId={chainId} isWrongNetwork={currentStep === 'wrongNetwork'} supportedNetworks={supportedChains} isMetamask={isMetamask(provider)} changeNetwork={this.changeMetamaskNetwork} />}
         {currentStep === 'chooseNetwork' && (
           <ChooseNetworkComponent
+            providerName={provider.name}
             networkParamsOptions={networkParamsOptions}
             rpcUrls={rpcUrls}
             chooseNetwork={this.chooseNetwork} />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,4 +12,4 @@ export const RLOGIN_SELECTED_PROVIDER = 'RLOGIN_SELECTED_PROVIDER'
 
 export const DONT_SHOW_AGAIN_KEY = 'RLogin:DontShowAgain'
 
-export const ETHEREUM_DPATH = "m/44'/60'/0'/0"
+export const ETHEREUM_DPATH = "m/44'/60'/0'/0/0"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,3 +11,5 @@ export const DONT_SHOW_TUTORIAL_AGAIN_KEY_DCENT = 'RLogin:DontShowTutorialAgain:
 export const RLOGIN_SELECTED_PROVIDER = 'RLOGIN_SELECTED_PROVIDER'
 
 export const DONT_SHOW_AGAIN_KEY = 'RLogin:DontShowAgain'
+
+export const ETHEREUM_DPATH = "m/44'/60'/0'/0"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,5 +11,3 @@ export const DONT_SHOW_TUTORIAL_AGAIN_KEY_DCENT = 'RLogin:DontShowTutorialAgain:
 export const RLOGIN_SELECTED_PROVIDER = 'RLOGIN_SELECTED_PROVIDER'
 
 export const DONT_SHOW_AGAIN_KEY = 'RLogin:DontShowAgain'
-
-export const ETHEREUM_DPATH = "m/44'/60'/0'/0/0"

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -66,7 +66,8 @@ const resources = {
       Path: 'Path',
       Address: 'Address',
       Balance: 'Balance',
-      'Or use the textbox to choose a specific path:': 'Or use the textbox to choose a specific path:'
+      'Or use the textbox to choose a specific path:': 'Or use the textbox to choose a specific path:',
+      'Use Ethereum path (check this if you used to connect with Metamask)': 'Use Ethereum path (check this if you used to connect with Metamask)'
     }
   },
   es: {

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
+import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 import { Header2, Paragraph } from '../../ui/shared/Typography'
 import LoadingComponent from '../../ui/shared/Loading'
 import { Button } from '../../ui/shared/Button'
 import AccountRow from './AccountRow'
 import { Trans } from 'react-i18next'
 import { getGasNameFromChain } from '../../adapters'
+import { ETHEREUM_DPATH } from '../..'
 
 export interface AccountInterface {
   index: number
@@ -72,9 +74,11 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     setIsLoading(true)
     setViewAbleAccounts([])
 
-    const currentIndexes = Array.from({ length: 5 }, (_, i) => i + startingIndex)
+    // if the provider's path is set to Ethereum, use that, else use the ChainIds:
+    const chainId = (provider.path === ETHEREUM_DPATH || provider.dpath === ETHEREUM_DPATH) ? 1 : provider.chainId
+    const nextPaths = [0, 1, 2, 3, 4].map(int => getDPathByChainId(chainId, int))
 
-    provider.getAddresses(currentIndexes)
+    provider.getAddresses(nextPaths)
       .then((accounts: AccountInterface[]) => {
         const balanceRequests = accounts.map((account) =>
           provider.request({

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 import { Header2, Paragraph } from '../../ui/shared/Typography'
 import LoadingComponent from '../../ui/shared/Loading'
 import { Button } from '../../ui/shared/Button'
 import AccountRow from './AccountRow'
 import { Trans } from 'react-i18next'
 import { getGasNameFromChain } from '../../adapters'
-import { ETHEREUM_DPATH } from '../..'
 
 export interface AccountInterface {
   index: number

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -74,7 +74,7 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
 
     // if the provider's path is set to Ethereum, use that, else use the ChainIds:
     const baseDpath = (provider.path || provider.dpath).split('/').slice(0, -1).join('/')
-    const nextPaths = [0, 1, 2, 3, 4].map(index => `${baseDpath}/${index}`)
+    const nextPaths = Array.from({ length: 5 }, (_, i) => i + startingIndex).map(index => `${baseDpath}/${index}`)
 
     provider.getAddresses(nextPaths)
       .then((accounts: AccountInterface[]) => {

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -75,8 +75,8 @@ export const ChooseDPathComponent: React.FC<Interface> = ({
     setViewAbleAccounts([])
 
     // if the provider's path is set to Ethereum, use that, else use the ChainIds:
-    const chainId = (provider.path === ETHEREUM_DPATH || provider.dpath === ETHEREUM_DPATH) ? 1 : provider.chainId
-    const nextPaths = [0, 1, 2, 3, 4].map(int => getDPathByChainId(chainId, int))
+    const baseDpath = (provider.path || provider.dpath).split('/').slice(0, -1).join('/')
+    const nextPaths = [0, 1, 2, 3, 4].map(index => `${baseDpath}/${index}`)
 
     provider.getAddresses(nextPaths)
       .then((accounts: AccountInterface[]) => {

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import ChooseNetworkComponent from './ChooseNetworkComponent'
+import { ETHEREUM_DPATH } from '../..'
 
 describe('Component: ChooseNetworkComponent', () => {
   const sharedProps = {
@@ -11,7 +12,7 @@ describe('Component: ChooseNetworkComponent', () => {
       31: 'http://31'
     },
     chooseNetwork: jest.fn(),
-    providerName: 'provider'
+    providerName: 'Metamask'
   }
 
   it('renders the component', () => {
@@ -35,5 +36,25 @@ describe('Component: ChooseNetworkComponent', () => {
 
     wrapper.find('button').simulate('click')
     expect(localProps.chooseNetwork).toBeCalledWith({ chainId: 1, rpcUrl: 'http://1' })
+  })
+
+  it('handles the ethereum/metamask checkbox', () => {
+    const localProps = {
+      ...sharedProps,
+      chooseNetwork: jest.fn(),
+      providerName: 'Ledger'
+    }
+    const wrapper = mount(<ChooseNetworkComponent {...localProps} />)
+
+    wrapper.find('select').at(0).simulate('change', {
+      target: { value: '30', name: 'RSK Mainnet' }
+    })
+
+    wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: true } })
+
+    wrapper.find('button').simulate('click')
+    expect(localProps.chooseNetwork).toBeCalledWith({
+      chainId: 30, rpcUrl: 'http://30', dPath: ETHEREUM_DPATH
+    })
   })
 })

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -12,7 +12,7 @@ describe('Component: ChooseNetworkComponent', () => {
       31: 'http://31'
     },
     chooseNetwork: jest.fn(),
-    providerName: 'Metamask'
+    providerName: 'provider'
   }
 
   it('renders the component', () => {

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.test.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import ChooseNetworkComponent from './ChooseNetworkComponent'
-import { ETHEREUM_DPATH } from '../..'
 
 describe('Component: ChooseNetworkComponent', () => {
   const sharedProps = {
@@ -54,7 +53,7 @@ describe('Component: ChooseNetworkComponent', () => {
 
     wrapper.find('button').simulate('click')
     expect(localProps.chooseNetwork).toBeCalledWith({
-      chainId: 30, rpcUrl: 'http://30', dPath: ETHEREUM_DPATH
+      chainId: 30, rpcUrl: 'http://30', dPath: "m/44'/60'/0'/0/0"
     })
   })
 })

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -8,6 +8,7 @@ import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
 import Checkbox from '../../ui/shared/Checkbox'
+import { ETHEREUM_DPATH } from '../..'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
@@ -35,7 +36,7 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
       chainId: parseInt(selectedChainId),
       rpcUrl: rpcUrls[selectedChainId],
       networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]),
-      dPath: customPath ? "m/44'/60'/0'/0" : undefined
+      dPath: customPath ? ETHEREUM_DPATH : undefined
     })
   }
 

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -57,15 +57,17 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
         </Select>
       </p>
       {showMigrationMessage && (
-        <div>
+        <>
           <Checkbox checked={customPath} onChange={toggleCheckBox} />
           {' '}
-          <label onClick={toggleCheckBox}>
+          <label onClick={toggleCheckBox} className="checkbox-label">
             <SmallSpan>
-            Use the Ethereum path if migrating from Metamask.
+              <Trans>
+              Use Ethereum path (check this if you used to connect with Metamask)
+              </Trans>
             </SmallSpan>
           </label>
-        </div>
+        </>
       )}
       <p>
         <Button disabled={isLoading} onClick={handleSelect}>Choose</Button>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -8,7 +8,7 @@ import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
 import Checkbox from '../../ui/shared/Checkbox'
-import { ETHEREUM_DPATH } from '../..'
+import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
@@ -28,7 +28,7 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
   }
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [customPath, setCustomPath] = useState<boolean>(false)
+  const [useEthereumDpath, setUseEthereumDpath] = useState<boolean>(false)
 
   const handleSelect = () => {
     setIsLoading(true)
@@ -36,11 +36,11 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
       chainId: parseInt(selectedChainId),
       rpcUrl: rpcUrls[selectedChainId],
       networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]),
-      dPath: customPath ? ETHEREUM_DPATH : undefined
+      dPath: useEthereumDpath ? getDPathByChainId(1, 0) : undefined
     })
   }
 
-  const toggleCheckBox = () => setCustomPath(!customPath)
+  const toggleCheckBox = () => setUseEthereumDpath(!useEthereumDpath)
 
   const showMigrationMessage =
     (providerName === 'Ledger' || providerName === 'Trezor') &&
@@ -58,7 +58,7 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
       </p>
       {showMigrationMessage && (
         <>
-          <Checkbox checked={customPath} onChange={toggleCheckBox} />
+          <Checkbox checked={useEthereumDpath} onChange={toggleCheckBox} />
           {' '}
           <label onClick={toggleCheckBox} className="checkbox-label">
             <SmallSpan>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -2,33 +2,50 @@
 import React, { useState } from 'react'
 import { Trans } from 'react-i18next'
 
-import { Header2 } from '../../ui/shared/Typography'
+import { Header2, SmallSpan } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
 import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
+import Checkbox from '../../ui/shared/Checkbox'
+import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
   networkParamsOptions?: NetworkParamsAllOptions
-  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams }) => void,
+  providerName?: string,
+  chooseNetwork: (network: { chainId: number, rpcUrl?: string, networkParams?:NetworkParams, dPath?: string }) => void
 }
 
 const ChooseNetworkComponent: React.FC<Interface> = ({
   rpcUrls,
   networkParamsOptions,
+  providerName,
   chooseNetwork
 }) => {
   if (!rpcUrls) {
     return <></>
   }
+  console.log('@jesse', providerName)
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [customPath, setCustomPath] = useState<boolean>(false)
 
   const handleSelect = () => {
     setIsLoading(true)
-    chooseNetwork({ chainId: parseInt(selectedChainId), rpcUrl: rpcUrls[selectedChainId], networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]) })
+    chooseNetwork({
+      chainId: parseInt(selectedChainId),
+      rpcUrl: rpcUrls[selectedChainId],
+      networkParams: (networkParamsOptions && networkParamsOptions[selectedChainId]),
+      dPath: customPath ? "m/44'/60'/0'/0" : undefined
+    })
   }
+
+  const toggleCheckBox = () => setCustomPath(!customPath)
+
+  const showMigrationMessage =
+    (providerName === 'Ledger' || providerName === 'Trezor') &&
+    selectedChainId !== '1'
 
   return (
     <div>
@@ -40,6 +57,17 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
           )}
         </Select>
       </p>
+      {showMigrationMessage && (
+        <div>
+          <Checkbox checked={customPath} onChange={toggleCheckBox} />
+          {' '}
+          <label onClick={toggleCheckBox}>
+            <SmallSpan>
+            Use the Ethereum path if migrating from Metamask.
+            </SmallSpan>
+          </label>
+        </div>
+      )}
       <p>
         <Button disabled={isLoading} onClick={handleSelect}>Choose</Button>
       </p>

--- a/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
+++ b/src/ux/chooseNetwork/ChooseNetworkComponent.tsx
@@ -8,7 +8,6 @@ import Select from '../../ui/shared/SelectDropdown'
 import { getChainName } from '../../adapters'
 import { NetworkParams, NetworkParamsAllOptions } from '../../lib/networkOptionsTypes'
 import Checkbox from '../../ui/shared/Checkbox'
-import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 
 interface Interface {
   rpcUrls?: {[key: string]: string}
@@ -26,7 +25,6 @@ const ChooseNetworkComponent: React.FC<Interface> = ({
   if (!rpcUrls) {
     return <></>
   }
-  console.log('@jesse', providerName)
   const [selectedChainId, setSelectedChainId] = useState<string>(Object.keys(rpcUrls)[0])
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [customPath, setCustomPath] = useState<boolean>(false)


### PR DESCRIPTION
Allows the user to use the Ethereum derivation path when connecting to a network that is not Ethereum. This is to assist users who were previously using Metamask to connect their hardware wallets. 

## Example:

**upfront**
![Screen Shot 2022-02-16 at 2 34 15 PM](https://user-images.githubusercontent.com/766679/154265421-26c5bfe8-98f0-4565-833c-d2ab2f8755df.png)

**after connecting**

![Screen Shot 2022-02-15 at 12 15 38 PM](https://user-images.githubusercontent.com/766679/154041263-236412de-e84c-4c75-96ed-3715ab5a966a.png)

## Todo list

This will require a small change in the providers to select the correct path.

- [x] Ledger and Trezor Providers - https://github.com/rsksmart/rLogin-providers/pull/45/
- [x] Publish beta4 versions of the providers
- [x] Update links here to use new package versions
- [ ] Add translations

