### PR TITLE
Show WalletConnect on mobile viewport

### DIFF
--- a/cypress/integration/4-mobile/mobile-integration.js
+++ b/cypress/integration/4-mobile/mobile-integration.js
@@ -1,0 +1,12 @@
+describe('rLoign modal interaction', () => {
+  beforeEach(() => {
+    cy.visit('/')
+    cy.contains('login with rLogin').click()
+  })
+
+  it('shows a QR code for WalletConnect', () => {
+    cy.viewport(480, 750)
+    cy.contains('WalletConnect').click()
+    cy.get('#walletconnect-qrcode-text').should('exist')
+  })
+})

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -86,7 +86,7 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
         <Provider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={false} />
         <Provider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
-      <ProviderRow className={PROVIDERS_MOBILE} hideMobile={true}>
+      <ProviderRow className={PROVIDERS_MOBILE}>
         <Provider userProvider={providersByName[providers.WALLETCONNECT.name] || providers.WALLETCONNECT} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>
       <ProviderRow className={PROVIDERS_CUSTODIAL}>


### PR DESCRIPTION
WalletConnect was hidden on mobile viewports, this removes that requirement. Also, CY test for mobile.

Resolves #226 