### PR TITLE
Modify theme colors when choosing derivation path

### DIFF
--- a/src/ux/chooseDpath/AccountRow.tsx
+++ b/src/ux/chooseDpath/AccountRow.tsx
@@ -13,16 +13,19 @@ interface Interface {
 
 const DpathRowStyles = styled.button<{ selected: boolean }>`
   display: flex;
-  background: ${(props) => props.selected ? props.theme.overlay : props.theme.primaryText};
+  background: ${(props) => props.selected ? props.theme.secondaryBackground : 'none'};
   border: none;
   border-radius: 5px;
   padding: 5px;
   margin-bottom: 5px;
   font-weight: 400 !important;
   font-size: 12px;
-  color: ${(props) => props.selected ? props.theme.primaryText : props.theme.p};
+  color: ${(props) => props.theme.p};
   width: 100%;
-  cursor: pointer
+  cursor: pointer;
+  &:hover {
+    background: ${(props) => props.theme.secondaryHoverBackground};
+  }
 `
 
 const Column = styled.div`

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -35,6 +35,7 @@ const Row = styled.div`
   color: ${props => props.theme.h3};
   border-bottom: ${(props) => `1px solid ${props.theme.p}`};
   padding-bottom: 5px;
+  margin-bottom: 5px;
 `
 
 export const Column = styled.div`

--- a/src/ux/chooseDpath/ChooseDPath.tsx
+++ b/src/ux/chooseDpath/ChooseDPath.tsx
@@ -18,6 +18,8 @@ const DPathInput = styled.input`
   border: none;
   border-bottom: ${(props) => `1px solid ${props.theme.p}`};
   color: ${props => props.theme.p};
+  background-color: transparent;
+  margin: 5px 0;
   padding: 5px;
   margin-left: 10px;
   &:focus {


### PR DESCRIPTION
## featuring

- Changes the hover color for the selected row to a color that works on both light and dark mode.
- Adds hover color
- Removes input background color for better design with dark mode

## demos

![Screen Shot 2022-03-15 at 1 13 31 PM](https://user-images.githubusercontent.com/766679/158366504-420cce9a-99e0-4271-88bb-8daced7f49d0.png)
![Screen Shot 2022-03-15 at 1 14 01 PM](https://user-images.githubusercontent.com/766679/158366515-5dc67c73-73d6-4cfc-9b3e-efe2e046657f.png)

Resolves #234 