### PR TITLE
Use the typeShared property instead of a single font.

### DIFF
--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -67,6 +67,8 @@ export class RLogin {
       ...opts
     }
 
+    console.log('@JESSE constructor', 6)
+
     // setup provider controller
     this.providerController = new RLoginProviderController({
       disableInjectedProvider: options.disableInjectedProvider,

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -67,8 +67,6 @@ export class RLogin {
       ...opts
     }
 
-    console.log('@JESSE constructor', 6)
-
     // setup provider controller
     this.providerController = new RLoginProviderController({
       disableInjectedProvider: options.disableInjectedProvider,

--- a/src/ui/modal/ModalLightbox.tsx
+++ b/src/ui/modal/ModalLightbox.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { typeShared } from '../shared/Typography';
+import { typeShared } from '../shared/Typography'
 
 interface ModalLightboxProps {
   show: boolean;

--- a/src/ui/modal/ModalLightbox.tsx
+++ b/src/ui/modal/ModalLightbox.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { typeShared } from '../shared/Typography';
 
 interface ModalLightboxProps {
   show: boolean;
@@ -6,7 +7,7 @@ interface ModalLightboxProps {
 }
 
 export const ModalLightbox = styled.div<ModalLightboxProps>`
-font-family: Rubik;
+${typeShared}
 transition: opacity 0.1s ease-in-out;
 text-align: center;
 position: fixed;


### PR DESCRIPTION
There were two fonts that were requested when running rLogin, `Rubik` and `Roboto`. Both of these fonts are san-serif fonts and if the browser does not have them, `Roboto` had [a fallback](https://github.com/rsksmart/rLogin/blob/develop/src/ui/shared/Typography.tsx#L10) to `sans-serif` . However, the `Rubik` font declaration had no fallback and by default browsers will use `serif`. This results in the ugly typography found in recent screenshots:

![Screen Shot 2022-03-15 at 1 27 03 PM](https://user-images.githubusercontent.com/766679/158368173-96f262b1-2d2d-46a9-9ff5-b194e96dd618.png)

This PR defaults all font-family properties to a single source with a fallback of 'sans-serif'.

