### PR TITLE
Refactor when/how confirmInformation is shown

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,6 +16,7 @@ jobs:
           build: npm run build
           start: npm run sample:cypress
           record: false
+          wait-on-timeout: 120
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           build: npm run build
           start: npm run sample:cypress
-          record: true
+          record: false
           wait-on-timeout: 120
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           build: npm run build
           start: npm run sample:cypress
-          record: false
+          record: true
           wait-on-timeout: 120
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -95,6 +95,25 @@ describe('cache provider tests', () => {
       cy.get('#login').click()
       cy.get('.rlogin-header2').should('have.text', 'Connect your wallet')
     })
+
+    it('shows the change network prompt', () => {
+      cy.visit('/?cache=yes', {
+        onBeforeLoad: function (window) {
+          const localProvider = currentProvider({
+            address,
+            privateKey,
+            chainId: 1000,
+            debug: true
+          })
+
+          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.ethereum = localProvider
+        }
+      })
+
+      cy.get('#login').click()
+      cy.get('h2.rlogin-header2').should('have.text', 'Select Network')
+    })
   })
 
   describe('sample:permissioned', () => {

--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -99,14 +99,15 @@ describe('cache provider tests', () => {
     it('shows the change network prompt', () => {
       cy.visit('/?cache=yes', {
         onBeforeLoad: function (window) {
-          const localProvider = currentProvider({
+          const localProvider = new MockProvider({
             address,
             privateKey,
-            chainId: 1000,
+            networkVersion: 1000,
             debug: true
           })
 
           window.localStorage.setItem('RLOGIN_CACHED_PROVIDER', '"injected"')
+          window.localStorage.setItem('RLOGIN_SELECTED_PROVIDER', rLoginCached)
           window.ethereum = localProvider
         }
       })

--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -106,7 +106,7 @@ describe('cache provider tests', () => {
             debug: true
           })
 
-          window.localStorage.setItem('WEB3_CONNECT_CACHED_PROVIDER', '"injected"')
+          window.localStorage.setItem('RLOGIN_CACHED_PROVIDER', '"injected"')
           window.ethereum = localProvider
         }
       })

--- a/cypress/integration/2-sample-app/sampleDapp_spec.js
+++ b/cypress/integration/2-sample-app/sampleDapp_spec.js
@@ -196,7 +196,6 @@ describe('sample:dapp testing, no backend', () => {
     cy.get('#connected').should('have.text', 'Yes')
     cy.get('#changeNetwork').click()
 
-    cy.get('.rlogin-header2').should('have.text', 'Select Network')
-    cy.get('.changeNetwork').should('be.visible')
+    cy.get('.rlogin-header2').should('have.text', 'Choose Network')
   })
 })

--- a/cypress/integration/3-permissioned-app/permissioned_spec.js
+++ b/cypress/integration/3-permissioned-app/permissioned_spec.js
@@ -10,6 +10,8 @@ describe('permissioned e2e testing', () => {
   const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
   beforeEach(() => {
+    cy.clearLocalStorage('RLogin:DontShowAgain')
+
     cy.on('window:before:load', (win) => {
       win.ethereum = new MockProvider({
         address,
@@ -78,6 +80,7 @@ describe('permissioned e2e testing', () => {
 
     cy.get('#access-token').should('not.be.empty')
     cy.get('#refresh-token').should('not.be.empty')
+    expectModalToBeHidden()
   })
 
   it('attempts to relogin into the datavault if failed.', () => {
@@ -273,8 +276,6 @@ describe('permissioned e2e testing', () => {
 
     cy.wait('@signup').its('response.statusCode').should('equal', 401)
     cy.wait('@signup').its('response.statusCode').should('equal', 200)
-
-    cy.contains('Confirm').click()
 
     cy.get('#access-token').should('have.text', 'accessTokenJWT')
     cy.get('#refresh-token').should('have.text', 'refreshTokenJWW')

--- a/cypress/integration/3-permissioned-app/permissioned_spec.js
+++ b/cypress/integration/3-permissioned-app/permissioned_spec.js
@@ -162,4 +162,25 @@ describe('permissioned e2e testing', () => {
 
     testHasNoAuthKeys()
   })
+
+  it('shows connection window with cache provider set true', () => {
+    cy.visit('/?backend=yes', {
+      onBeforeLoad: function (window) {
+        window.localStorage.setItem('RLOGIN_CACHED_PROVIDER', '"injected"')
+        window.localStorage.setItem('RLogin:DontShowAgain', 'true')
+      }
+    })
+
+    cy.get('#login').click()
+
+    // rLogin makes 3 post requests to this URL, we will wait but not mock as they need to increment.
+    cy.intercept('POST', 'https://did.rsk.co:4444/').as('didRsk')
+    cy.wait('@didRsk')
+
+    // mock response from the app
+    cy.intercept('GET', 'http(.+)request-signup(.+)', { fixture: 'request-signup.json' }).as('requestSignup')
+
+    // expect statement:
+    cy.get('.rlogin-header2').should('have.text', 'Would you like to give us access to info in your data vault?')
+  })
 })

--- a/src/Core.test.tsx
+++ b/src/Core.test.tsx
@@ -28,8 +28,6 @@ describe('Component: Core', () => {
       <Core
         userProviders={[provider]}
         onClose={jest.fn()}
-        showModal={jest.fn()}
-        resetState={jest.fn()}
         providerController={new ProviderController(providerControllerOptions)}
         onConnect={jest.fn()}
         onLanguageChanged={jest.fn()}

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -377,7 +377,8 @@ export class Core extends React.Component<IModalProps, IModalState> {
 
      if (!backendUrl) {
        this.setState({
-         currentStep: 'confirmInformation'
+         currentStep: 'confirmInformation',
+         show: true
        })
      } else {
        const loadingReason = i18next.t('Connecting to server')

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -382,7 +382,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
        })
      } else {
        const loadingReason = i18next.t('Connecting to server')
-       this.setState({ loadingReason })
+       this.setState({ show: true, loadingReason })
        // request schema to back end
        return requestSignup(backendUrl!, this.did()).then(({ challenge, sdr }) => {
          this.setState({
@@ -411,7 +411,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
    }
 
    private onConfirmSelectiveDisclosure (sd: SD) {
-     this.setState({ sd, currentStep: 'confirmInformation' })
+     this.setState({ sd, currentStep: 'confirmInformation', show: true })
    }
 
    /** Step 3 */

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -405,8 +405,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
    }
 
    private onConfirmSelectiveDisclosure (sd: SD) {
-     this.setState({ sd })
-     this.shouldShowConfirmStep()
+     this.setState({ sd }, () => this.shouldShowConfirmStep())
    }
 
    /** Step 3 */

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -42,7 +42,7 @@ declare global {
   interface Window {
     ethereum: any;
     web3: any;
-    showRLoginModal: () => void;
+    showRLoginModal: (step?: Step) => void;
   }
 }
 
@@ -141,9 +141,9 @@ export class Core extends React.Component<IModalProps, IModalState> {
     super(props)
 
     // @JESSE using this method for now...
-    window.showRLoginModal = async () => {
-      console.log('[Core.tsx] showRLoginModal called')
-      return this.setState({ show: true })
+    window.showRLoginModal = async (step?: Step) => {
+      console.log('[Core.tsx] showRLoginModal called', step)
+      return this.setState({ show: true, currentStep: step || 'Step1' })
     }
 
     const { providerController, onError } = props
@@ -420,12 +420,14 @@ export class Core extends React.Component<IModalProps, IModalState> {
      const did = this.did()
 
      if (!backendUrl) {
+       this.setState({ show: false })
        return onConnect(provider, this.disconnect, this.selectedLanguageCode, this.selectedTheme, dataVault)
      }
 
      const handleConnect = (provider: any, authKeys: AuthKeys) => onConnect(provider, this.disconnect, this.selectedLanguageCode, this.selectedTheme, dataVault, authKeys)
 
      return confirmAuth(provider, address!, backendUrl!, did, challenge!, handleConnect, sd)
+       .then(() => this.setState({ show: false }))
        .catch((error: Error | AxiosError) => {
          // this error handling is added to help user when challenge expired. in that
          // case we ask for a new challenge and ask again the user to sign

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -159,7 +159,6 @@ export class Core extends React.Component<IModalProps, IModalState> {
     this.onConfirmAuth = this.onConfirmAuth.bind(this)
     this.disconnect = this.disconnect.bind(this)
     this.closeModal = this.closeModal.bind(this)
-    this.showModal = this.showModal.bind(this)
     this.preConnectChecklist = this.preConnectChecklist.bind(this)
     this.preTutorialChecklist = this.preTutorialChecklist.bind(this)
     this.chooseNetwork = this.chooseNetwork.bind(this)
@@ -251,8 +250,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         return false
       }
 
-      this.showModal()
-      this.setState({ currentStep: 'wrongNetwork' })
+      this.setState({ currentStep: 'wrongNetwork', show: true })
     }
 
     return isCurrentChainSupported
@@ -491,23 +489,19 @@ export class Core extends React.Component<IModalProps, IModalState> {
      onClose()
    }
 
-   private showModal () {
-     this.setState({ show: true })
-   }
-
   public changeLanguage = (language: string) => {
     const { onLanguageChanged } = this.props
 
     i18n.changeLanguage(language)
     onLanguageChanged(language)
-    this.showModal() // @jesse - is this needed?
+    this.setState({ show: true })
   }
 
   public changeTheme = (theme: themesOptions) => {
     const { onThemeChanged } = this.props
     this.setState({ currentTheme: theme })
     onThemeChanged(theme)
-    this.showModal() // @jesse - is this needed?
+    this.setState({ show: true })
   }
 
   public render = () => {

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -429,6 +429,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
          if ((error as AxiosError).response && (error as AxiosError).response?.data === 'INVALID_CHALLENGE_RESPONSE') {
            return requestSignup(backendUrl!, this.did()).then(({ challenge }) =>
              confirmAuth(provider, address!, backendUrl!, did, challenge!, handleConnect, sd)
+               .then(() => this.setState({ show: false }))
            )
          }
          throw error

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -42,7 +42,7 @@ declare global {
   interface Window {
     ethereum: any;
     web3: any;
-    updateWeb3Modal: any;
+    showRLoginModal: () => void;
   }
 }
 
@@ -61,8 +61,6 @@ export interface DataVaultOptions {
 interface IModalProps {
   userProviders: IProviderUserOptions[];
   onClose: SimpleFunction;
-  showModal: SimpleFunction;
-  resetState: SimpleFunction;
   providerController: any
   onConnect: (provider: any, disconnect: () => void, selectedLanguage:string, selectedTheme:themesOptions, dataVault?: IDataVault, authKeys?: AuthKeys) => Promise<void>
   onError: (error: any) => Promise<void>
@@ -142,7 +140,11 @@ export class Core extends React.Component<IModalProps, IModalState> {
   constructor (props: IModalProps) {
     super(props)
 
-    window.updateWeb3Modal = async (state: IModalState) => this.setState(state)
+    // @JESSE using this method for now...
+    window.showRLoginModal = async () => {
+      console.log('[Core.tsx] showRLoginModal called')
+      return this.setState({ show: true })
+    }
 
     const { providerController, onError } = props
 
@@ -159,6 +161,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     this.onConfirmAuth = this.onConfirmAuth.bind(this)
     this.disconnect = this.disconnect.bind(this)
     this.closeModal = this.closeModal.bind(this)
+    this.showModal = this.showModal.bind(this)
     this.preConnectChecklist = this.preConnectChecklist.bind(this)
     this.preTutorialChecklist = this.preTutorialChecklist.bind(this)
     this.chooseNetwork = this.chooseNetwork.bind(this)
@@ -236,7 +239,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
   })
 
   private validateCurrentChain ():boolean {
-    const { supportedChains, showModal, keepModalHidden, onError } = this.props
+    const { supportedChains, keepModalHidden, onError } = this.props
     const { chainId, provider } = this.state
 
     if (!Array.isArray(supportedChains) || supportedChains.length === 0) return true
@@ -250,7 +253,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
         return false
       }
 
-      showModal()
+      this.showModal()
       this.setState({ currentStep: 'wrongNetwork' })
     }
 
@@ -477,19 +480,24 @@ export class Core extends React.Component<IModalProps, IModalState> {
      onClose()
    }
 
+   private showModal () {
+     console.log('[Core] show()')
+     this.setState({ show: true })
+   }
+
   public changeLanguage = (language: string) => {
-    const { showModal, onLanguageChanged } = this.props
+    const { onLanguageChanged } = this.props
 
     i18n.changeLanguage(language)
     onLanguageChanged(language)
-    showModal()
+    this.showModal() // @jesse - is this needed?
   }
 
   public changeTheme = (theme: themesOptions) => {
-    const { showModal, onThemeChanged } = this.props
+    const { onThemeChanged } = this.props
     this.setState({ currentTheme: theme })
     onThemeChanged(theme)
-    showModal()
+    this.showModal() // @jesse - is this needed?
   }
 
   public render = () => {

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -179,14 +179,14 @@ export class RLogin {
       this.setupHandlers(resolve, reject)
 
       if (this.cachedProvider) {
-        return await this.providerController.connectToCachedProvider()
+        await this.providerController.connectToCachedProvider()
           .catch(err => {
             console.log('error on the cached provider!', err)
             reject(err)
           })
+      } else {
+        this.showModal()
       }
-
-      this.showModal()
     });
 
   /**

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -98,19 +98,10 @@ export class RLogin {
     return this.providerController.cachedProvider
   }
 
-  private showModal = () => {
-    console.log('[RLogin] showModal')
-    // call the window elemenet showRLoginModal() // refactor this later??
-    window.showRLoginModal()
-  }
-
-  public showWalletInfo = () => {
-    // this.updateState({ show: true, currentStep: 'walletInfo' })
-  }
-
-  public showChangeNetwork = () => {
-    // this.updateState({ show: true, currentStep: 'changeNetwork' })
-  }
+  // show/hide modal functions
+  private showModal = () => window.showRLoginModal()
+  public showWalletInfo = () => window.showRLoginModal('walletInfo')
+  public showChangeNetwork = () => window.showRLoginModal('chooseNetwork')
 
   /** handles an event and closes modal if open */
   private handleOnAndTrigger = async (event: string, ...args: any) =>

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -90,7 +90,6 @@ export class RLogin {
       this.themes.dark = { ...this.themes.dark, ...opts.customThemes.dark }
     }
     this.defaultTheme = (opts && opts.defaultTheme) ? opts.defaultTheme : defaultThemeConfig
-
     this.renderModal()
   }
 
@@ -103,15 +102,12 @@ export class RLogin {
   public showWalletInfo = () => window.showRLoginModal('walletInfo')
   public showChangeNetwork = () => window.showRLoginModal('chooseNetwork')
 
-  /** handles an event and closes modal if open */
+  /** handles an event */
   private handleOnAndTrigger = async (event: string, ...args: any) =>
     this.eventController.trigger(event, ...args)
 
   /** event handlers */
-  private onClose = () => {
-    // this.resetState()
-    this.handleOnAndTrigger(CLOSE_EVENT)
-  }
+  private onClose = () => this.handleOnAndTrigger(CLOSE_EVENT)
 
   private onConnect = (provider: any, disconnect: () => void, selectedLanguage:string, selectedTheme:themesOptions, dataVault?: DataVault, authKeys?: AuthKeys) => this.handleOnAndTrigger(CONNECT_EVENT, { provider, disconnect, selectedLanguage, selectedTheme, dataVault, authKeys })
   private onError = (error: any) => this.handleOnAndTrigger(ERROR_EVENT, error) // TODO: add a default error page

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -171,10 +171,7 @@ export class RLogin {
 
       if (this.cachedProvider) {
         await this.providerController.connectToCachedProvider()
-          .catch(err => {
-            console.log('error on the cached provider!', err)
-            reject(err)
-          })
+          .catch(reject)
       } else {
         this.showModal()
       }

--- a/src/ux/confirmInformation/ConfirmInformation.test.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.test.tsx
@@ -122,7 +122,7 @@ describe('Component: ConfirmInformation', () => {
   })
 
   it('shows dpath for hardware provider', () => {
-    const wrapper = mount(<ConfirmInformation {...props} providerName='Ledger' provider={{ dpath: 'dpath', isLedger: true }} />)
+    const wrapper = mount(<ConfirmInformation {...props} provider={{ dpath: 'dpath', isLedger: true }} />)
 
     expect(wrapper.find(`dt.${LIST_TITLE}`).at(2).text()).toBe('Derivation path:')
     expect(wrapper.find(`dd.${LIST_DESCRIPTION}`).at(2).text()).toBe('dpath')

--- a/src/ux/confirmInformation/ConfirmInformation.tsx
+++ b/src/ux/confirmInformation/ConfirmInformation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { SD } from '../../lib/sdr'
 import { Header2, SmallSpan, typeShared } from '../../ui/shared/Typography'
 import { Button } from '../../ui/shared/Button'
@@ -21,12 +21,11 @@ interface ConfirmInformationProps {
   sd: SD | undefined
   providerUserOption: IProviderUserOptions
   provider: any
-  providerName: string
   onConfirm: () => Promise<any>
   onCancel: () => void
 }
 
-export function ConfirmInformation ({ displayMode, chainId, address, providerUserOption, sd, provider, providerName, onConfirm, onCancel }: ConfirmInformationProps) {
+export function ConfirmInformation ({ displayMode, chainId, address, providerUserOption, sd, provider, onConfirm, onCancel }: ConfirmInformationProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [dontShowAgainSelected, setDontShowAgainSelected] = useState<boolean>(false)
   const data = sd ? Object.assign({}, sd.credentials, sd.claims) : {}
@@ -38,15 +37,6 @@ export function ConfirmInformation ({ displayMode, chainId, address, providerUse
 
     setIsLoading(false)
   }
-
-  useEffect(() => {
-    const DONT_SHOW_AGAIN_DEFAULT: boolean =
-      localStorage.getItem(DONT_SHOW_AGAIN_KEY) ? JSON.parse(localStorage.getItem(DONT_SHOW_AGAIN_KEY)!) : false
-
-    if (DONT_SHOW_AGAIN_DEFAULT && !displayMode) {
-      handleSubmit()
-    }
-  }, [displayMode])
 
   const peerWallet = getPeerInfo(provider?.wc?.peerMeta)
 


### PR DESCRIPTION
Hides the confirmScreen flash that happens as a result of the component showing and then deciding to hide. A new function called `shouldConfirmShow` was added in the Core to get the variable from localStorage and make the determination. 

This PR also limits RLogin's access to the Core's state and only allows show and to set a screen. 

