### PR TITLE
Remove window.rLogin reference

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,6 +17,7 @@ jobs:
           start: npm run sample:cypress
           record: false
           wait-on-timeout: 120
+          wait-on: 'http://localhost:3006'
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -199,7 +199,7 @@ export class Core extends React.Component<IModalProps, IModalState> {
     }
   }
 
-  // Interacts with RLogin to expose hide/show modal functions to the steps listed below:
+  // Interacts with RLogin to expose hide/show modal functions to the steps listed below
   public showModalWithStep (step: 'Step1' | 'chooseNetwork' | 'walletInfo') {
     this.setState({ show: true, currentStep: step })
   }

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -140,10 +140,6 @@ export class Core extends React.Component<IModalProps, IModalState> {
   constructor (props: IModalProps) {
     super(props)
 
-    // Allows RLogin to hide/show the modal state
-    window.showRLoginModal = async (step?: Step) =>
-      this.setState({ show: true, currentStep: step || 'Step1' })
-
     const { providerController, onError } = props
 
     providerController.on(CONNECT_EVENT, (provider: any) => this.continueSettingUp(provider))

--- a/src/Core.tsx
+++ b/src/Core.tsx
@@ -199,6 +199,11 @@ export class Core extends React.Component<IModalProps, IModalState> {
     }
   }
 
+  // Interacts with RLogin to expose hide/show modal functions to the steps listed below:
+  public showModalWithStep (step: 'Step1' | 'chooseNetwork' | 'walletInfo') {
+    this.setState({ show: true, currentStep: step })
+  }
+
   private setupLanguages () {
     // this fetches all available languages in this form [{en:english},...]
     this.availableLanguages = Object.entries(i18next.services.resourceStore.data).map(keyValueLanguage => { return { code: keyValueLanguage[0], name: keyValueLanguage[1].name.toString() } })

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -58,7 +58,7 @@ export class RLogin {
   private defaultTheme: themesOptions
   private rpcUrls?: {[key: string]: string}
 
-  private coreRef: any
+  private coreRef: React.RefObject<Core>
 
   constructor (opts?: Options) {
     const options: IProviderControllerOptions = {
@@ -104,9 +104,9 @@ export class RLogin {
   }
 
   // show/hide modal functions
-  private showModal = () => this.coreRef.current.showModalWithStep('Step1')
-  public showWalletInfo = () => this.coreRef.current.showModalWithStep('walletInfo')
-  public showChangeNetwork = () => this.coreRef.current.showModalWithStep('chooseNetwork')
+  private showModal = () => this.coreRef.current?.showModalWithStep('Step1')
+  public showWalletInfo = () => this.coreRef.current?.showModalWithStep('walletInfo')
+  public showChangeNetwork = () => this.coreRef.current?.showModalWithStep('chooseNetwork')
 
   /** handles an event */
   private handleOnAndTrigger = async (event: string, ...args: any) =>

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -58,6 +58,8 @@ export class RLogin {
   private defaultTheme: themesOptions
   private rpcUrls?: {[key: string]: string}
 
+  private coreRef: any
+
   constructor (opts?: Options) {
     const options: IProviderControllerOptions = {
       ...defaultOpts,
@@ -90,6 +92,10 @@ export class RLogin {
       this.themes.dark = { ...this.themes.dark, ...opts.customThemes.dark }
     }
     this.defaultTheme = (opts && opts.defaultTheme) ? opts.defaultTheme : defaultThemeConfig
+
+    // create reference to core to be used with hiding/showing modal
+    this.coreRef = React.createRef()
+
     this.renderModal()
   }
 
@@ -98,9 +104,9 @@ export class RLogin {
   }
 
   // show/hide modal functions
-  private showModal = () => window.showRLoginModal()
-  public showWalletInfo = () => window.showRLoginModal('walletInfo')
-  public showChangeNetwork = () => window.showRLoginModal('chooseNetwork')
+  private showModal = () => this.coreRef.current.showModalWithStep('Step1')
+  public showWalletInfo = () => this.coreRef.current.showModalWithStep('walletInfo')
+  public showChangeNetwork = () => this.coreRef.current.showModalWithStep('chooseNetwork')
 
   /** handles an event */
   private handleOnAndTrigger = async (event: string, ...args: any) =>
@@ -134,6 +140,7 @@ export class RLogin {
 
     ReactDOM.render(
       <Core
+        ref={this.coreRef}
         onLanguageChanged={this.onLanguageChanged}
         onThemeChanged={this.onThemeChanged}
         userProviders={this.userProviders}


### PR DESCRIPTION
Rather than using `window.showRLoginModal`, create a reference to Core that can be called from RLogin to trigger the show and step variable. With this approach, it does not require a breaking change and removes setting the window variable.

Resolves #231
