### PR TITLE
Theme testing

### DIFF
--- a/cypress/integration/1-modal/rlogin-modal-theme_spec.js
+++ b/cypress/integration/1-modal/rlogin-modal-theme_spec.js
@@ -1,28 +1,103 @@
+import { mockInjectedProvider } from "../account"
+
+const openRLogin = () => cy.contains('login with rLogin').click()
+
+const switchTheme = () => cy.get('#theme-switcher').click()
+
+const testIsLight = () => cy.get('.rlogin-modal-card').should('have.css', 'background-color', 'rgb(255, 255, 255)')
+const testIsDark = () => cy.get('.rlogin-modal-card').should('have.css', 'background-color', 'rgb(0, 0, 0)')
+
 describe('rLoign modal interaction', () => {
   beforeEach(() => {
-    cy.visit('/')
-    cy.contains('login with rLogin').click()
+    mockInjectedProvider()
   })
 
-  it('default theme light', () => {
-    cy.get('.rlogin-modal-card').should('have.css', 'background-color', 'rgb(255, 255, 255)')
-  })
+  describe('default light', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      openRLogin()
+    })
 
-  it('change to dark theme should change color and event', () => {
-    cy.get('.rlogin-modal-card').should('have.css', 'background-color', 'rgb(255, 255, 255)')
-    cy.window().then((win) => {
-      win.rLogin.on('themeChanged', (theme) => {
-        // eslint-disable-next-line jest/valid-expect
-        expect(theme).to.eq('dark')
+    it('default theme light', () => {
+      testIsLight()
+    })
+
+    it('change to dark theme should change color and event', () => {
+      cy.window().then((win) => {
+        win.rLogin.on('themeChanged', (theme) => {
+          // eslint-disable-next-line jest/valid-expect
+          expect(theme).to.eq('dark')
+        })
+
+        switchTheme()
+        testIsDark()
       })
+    })
 
-      cy.get('#theme-switcher').click()
-      cy.get('.rlogin-modal-card').should('have.css', 'background-color', 'rgb(0, 0, 0)')
+    it('change to dark theme and go back to light', () => {
+      switchTheme()
+      switchTheme()
+      testIsLight()
     })
   })
 
-  it('change to dark theme and go back to light', () => {
-    cy.get('#theme-switcher').click().click()
-    cy.get('.rlogin-modal-card').should('have.css', 'background-color', 'rgb(255, 255, 255)')
+  describe('default dark', () => {
+    beforeEach(() => {
+      cy.visit('/?defaultTheme=dark')
+      openRLogin()
+    })
+
+    it('is initially dark', () => {
+      testIsDark()
+    })
+
+    it('changes to light and emits event', () => {
+      cy.window().then((win) => {
+        win.rLogin.on('themeChanged', (theme) => {
+
+          expect(theme).to.eq('light')
+        })
+
+        switchTheme()
+        testIsLight()
+      })
+    })
+
+    it('goes back to dark and emits event', () => {
+      let count = 0
+      cy.window().then((win) => {
+        win.rLogin.on('themeChanged', (theme) => {
+          count++
+
+          if (count == 2) expect(theme).to.eq('dark')
+        })
+
+        switchTheme()
+        switchTheme()
+        testIsDark()
+      })
+    })
+
+    it('shows confirm info in dark', () => {
+      cy.contains('MetaMask').click()
+      cy.get('.rlogin-header2').should('have.text', 'Successfully connected')
+      testIsDark()
+    })
+
+    it('shows wallet info in dark', () => {
+      cy.contains('MetaMask').click()
+      cy.get('.rlogin-button.confirm').click()
+      cy.get('#showInfo').click()
+      testIsDark()
+    })
+
+
+    it('shows wallet info in light after switching', () => {
+      switchTheme()
+      cy.contains('MetaMask').click()
+      cy.get('.rlogin-button.confirm').click()
+      cy.get('#showInfo').click()
+      testIsLight()
+    })
   })
 })

--- a/cypress/integration/1-modal/rlogin-networks_spec.js
+++ b/cypress/integration/1-modal/rlogin-networks_spec.js
@@ -1,20 +1,10 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 import { chainList } from '../../../src/chianList_test'
 
 describe('supported chain names', () => {
   chainList.forEach(([chainId, expectedName]) => {
     it(`connects to chain ${chainId} and displays ${expectedName}`, () => {
-
-      cy.on('window:before:load', (win) => {
-        win.ethereum = new MockProvider({
-          address,
-          privateKey,
-          networkVersion: chainId,
-          debug: true
-        })
-        win.ethereum.isMetaMask = true
-      })
+      mockInjectedProvider({ networkVersion: chainId })
 
       cy.visit('/')
       cy.get('#login').click()

--- a/cypress/integration/1-modal/rlogin-retry-provider_spec.js
+++ b/cypress/integration/1-modal/rlogin-retry-provider_spec.js
@@ -1,17 +1,9 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 
 describe('modal - chose metamask fails, then walletconnect works', () => {
   beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.ethereum = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 31,
-        debug: true
-      })
-      win.ethereum.isMetaMask = true
-      win.ethereum.request = () => Promise.reject(new Error('an error'))
+    mockInjectedProvider({}, (provider) => {
+      provider.request = () => Promise.reject(new Error('an error'))
     })
   })
 

--- a/cypress/integration/1-modal/rlogin-triggers_spec.js
+++ b/cypress/integration/1-modal/rlogin-triggers_spec.js
@@ -1,17 +1,8 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 
 describe('triggers', () => {
   beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.ethereum = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 31,
-        debug: true
-      })
-      win.ethereum.isMetaMask = true
-    })
+    mockInjectedProvider()
   })
 
   const loginWithModal = (withCacheProvider = false) => {

--- a/cypress/integration/1-modal/rlogin-user-confirmation_spec.js
+++ b/cypress/integration/1-modal/rlogin-user-confirmation_spec.js
@@ -1,21 +1,8 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 
 describe('rLogin modal loading while user confirms wallet', () => {
   beforeEach(() => {
-    const provider = new MockProvider({
-      address,
-      privateKey,
-      networkVersion: 31,
-      debug: true,
-      manualConfirmEnable: true
-    })
-
-    provider.isMetaMask = true
-
-    cy.on('window:before:load', (win) => {
-      win.ethereum = provider
-    })
+    mockInjectedProvider({ manualConfirmEnable: true })
     cy.visit('/')
     cy.contains('login with rLogin').click()
   })

--- a/cypress/integration/2-sample-app/cacheProvider_spec.js
+++ b/cypress/integration/2-sample-app/cacheProvider_spec.js
@@ -1,5 +1,5 @@
 import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { privateKey, address, mockInjectedProvider } from '../account'
 
 describe('cache provider tests', () => {
   const rLoginCached = JSON.stringify({
@@ -11,15 +11,7 @@ describe('cache provider tests', () => {
   })
 
   beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.ethereum = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 31,
-        debug: true
-      })
-      win.ethereum.isMetaMask = true
-    })
+    mockInjectedProvider()
   })
 
   it('logs in as normal', () => {

--- a/cypress/integration/2-sample-app/hardwareProvider_spec.js
+++ b/cypress/integration/2-sample-app/hardwareProvider_spec.js
@@ -1,5 +1,4 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 
 describe('hardware provider tests', () => {
   const rLoginCached = JSON.stringify({
@@ -15,18 +14,9 @@ describe('hardware provider tests', () => {
   })
 
   beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      const provider = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 31,
-        debug: true
-      })
-
+    mockInjectedProvider({}, (provider) => {
       provider.isMetaMask = null
       provider.isLedger = true
-
-      win.ethereum = provider
     })
   })
 

--- a/cypress/integration/2-sample-app/providerError_spec.js
+++ b/cypress/integration/2-sample-app/providerError_spec.js
@@ -1,21 +1,9 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 
 describe('Web3 Provider throws an error when connecting', () => {
   beforeEach(() => {
-    const provider = new MockProvider({
-      address,
-      privateKey,
-      networkVersion: 31,
-      debug: true
-    })
-
-    // overwrite the enable method to throw an error:
-    provider.request = (_props) => Promise.reject(new Error('Not today'))
-    provider.isMetaMask = true
-
-    cy.on('window:before:load', (win) => {
-      win.ethereum = provider
+    mockInjectedProvider({}, (provider) => {
+      provider.request = (_props) => Promise.reject(new Error('Not today'))
     })
   })
 

--- a/cypress/integration/2-sample-app/sampleDapp_spec.js
+++ b/cypress/integration/2-sample-app/sampleDapp_spec.js
@@ -1,17 +1,8 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { address, mockInjectedProvider } from '../account'
 
 describe('sample:dapp testing, no backend', () => {
   beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.ethereum = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 31,
-        debug: true
-      })
-      win.ethereum.isMetaMask = true
-    })
+    mockInjectedProvider()
   })
 
   const loginWithModal = (withCacheProvider = false) => {

--- a/cypress/integration/2-sample-app/wrongNetwork_spec.js
+++ b/cypress/integration/2-sample-app/wrongNetwork_spec.js
@@ -1,17 +1,8 @@
-import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { mockInjectedProvider } from '../account'
 
 describe('show Select Network modal when trying to connect with a unsupported chainId', () => {
   beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.ethereum = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 2,
-        debug: true
-      })
-      win.ethereum.isMetaMask = true
-    })
+    mockInjectedProvider({ networkVersion: 2 })
   })
 
   it('shows the Select Network modal when using connect', () => {

--- a/cypress/integration/3-permissioned-app/permissioned_spec.js
+++ b/cypress/integration/3-permissioned-app/permissioned_spec.js
@@ -1,5 +1,5 @@
 import { MockProvider } from '@rsksmart/mock-web3-provider'
-import { privateKey, address } from '../account'
+import { privateKey, address, mockInjectedProvider } from '../account'
 
 const testHasNoAuthKeys = () => {
   cy.get('#access-token').should('be.empty')
@@ -9,16 +9,7 @@ const testHasNoAuthKeys = () => {
 describe('permissioned e2e testing', () => {
   beforeEach(() => {
     cy.clearLocalStorage('RLogin:DontShowAgain')
-
-    cy.on('window:before:load', (win) => {
-      win.ethereum = new MockProvider({
-        address,
-        privateKey,
-        networkVersion: 31,
-        debug: true
-      })
-      win.ethereum.isMetaMask = true
-    })
+    mockInjectedProvider()
   })
 
   const connectToMetamask = () => {

--- a/cypress/integration/account.js
+++ b/cypress/integration/account.js
@@ -1,2 +1,15 @@
+import { MockProvider } from '@rsksmart/mock-web3-provider'
+
 export const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
 export const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
+
+export const mockInjectedProvider = () => {
+  cy.on('window:before:load', (win) => {
+    win.ethereum = new MockProvider({
+      address,
+      privateKey,
+      networkVersion: 31,
+      debug: true
+    })
+  })
+}

--- a/cypress/integration/account.js
+++ b/cypress/integration/account.js
@@ -3,14 +3,19 @@ import { MockProvider } from '@rsksmart/mock-web3-provider'
 export const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
 export const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
-export const mockInjectedProvider = (setupOverrides = {}) => {
+export const mockInjectedProvider = (setupOverrides = {}, beforeLoad) => {
   const setup = Object.assign({}, {
     address,
     privateKey,
     networkVersion: 31,
     debug: true
   }, setupOverrides)
+
+  const provider = new MockProvider(setup)
+
+  if (beforeLoad) beforeLoad(provider)
+
   cy.on('window:before:load', (win) => {
-    win.ethereum = new MockProvider(setup)
+    win.ethereum = provider
   })
 }

--- a/cypress/integration/account.js
+++ b/cypress/integration/account.js
@@ -3,13 +3,14 @@ import { MockProvider } from '@rsksmart/mock-web3-provider'
 export const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
 export const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
-export const mockInjectedProvider = () => {
+export const mockInjectedProvider = (setupOverrides = {}) => {
+  const setup = Object.assign({}, {
+    address,
+    privateKey,
+    networkVersion: 31,
+    debug: true
+  }, setupOverrides)
   cy.on('window:before:load', (win) => {
-    win.ethereum = new MockProvider({
-      address,
-      privateKey,
-      networkVersion: 31,
-      debug: true
-    })
+    win.ethereum = new MockProvider(setup)
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",
-        "@rsksmart/mock-web3-provider": "^1.0.0",
+        "@rsksmart/mock-web3-provider": "^1.0.1",
         "@rsksmart/rlogin-dpath": "^1.0.1",
         "@rsksmart/vc-json-schemas-parser": "^1.0.0",
         "@types/styled-components": "^5.1.3",
@@ -2747,9 +2747,9 @@
       "integrity": "sha512-SKHgsjVysiIVv6xyDOVuubVPVT7qMQ0y7IWOj2j73Hmgq/dSgyouXc2kl6THh0Vqh9ri5J3R+rKuXRzXmv/HvA=="
     },
     "node_modules/@rsksmart/mock-web3-provider": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/mock-web3-provider/-/mock-web3-provider-1.0.0.tgz",
-      "integrity": "sha512-xzE2lDvvUmq1Osy1EUsGlLg0YwygjaQu9LR3UjDOtXbLz/AT9b0tzyO5hB9hXt32Hz6UOArRH/cNCQwCOzXn5g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/mock-web3-provider/-/mock-web3-provider-1.0.1.tgz",
+      "integrity": "sha512-29syghh9X2ju80HXtH2O/tXEkUloCORo1lssLx70Trr1fiaxvpH5sxcFBDzjF0XPwwlrj3pqoQc34sL8EiUNYg==",
       "dependencies": {
         "eth-sig-util": "^3.0.1"
       }
@@ -23802,9 +23802,9 @@
       "integrity": "sha512-SKHgsjVysiIVv6xyDOVuubVPVT7qMQ0y7IWOj2j73Hmgq/dSgyouXc2kl6THh0Vqh9ri5J3R+rKuXRzXmv/HvA=="
     },
     "@rsksmart/mock-web3-provider": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/mock-web3-provider/-/mock-web3-provider-1.0.0.tgz",
-      "integrity": "sha512-xzE2lDvvUmq1Osy1EUsGlLg0YwygjaQu9LR3UjDOtXbLz/AT9b0tzyO5hB9hXt32Hz6UOArRH/cNCQwCOzXn5g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/mock-web3-provider/-/mock-web3-provider-1.0.1.tgz",
+      "integrity": "sha512-29syghh9X2ju80HXtH2O/tXEkUloCORo1lssLx70Trr1fiaxvpH5sxcFBDzjF0XPwwlrj3pqoQc34sL8EiUNYg==",
       "requires": {
         "eth-sig-util": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",
-    "@rsksmart/mock-web3-provider": "^1.0.0",
+    "@rsksmart/mock-web3-provider": "^1.0.1",
     "@rsksmart/rlogin-dpath": "^1.0.1",
     "@rsksmart/vc-json-schemas-parser": "^1.0.0",
     "@types/styled-components": "^5.1.3",

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -71,15 +71,17 @@
         window.ethereum.autoRefreshOnNetworkChange = false
       }
 
+      const urlSearchParams = new URLSearchParams(window.location.search)
+
       // detect flavor
-      const withBackend = new URLSearchParams(window.location.search).get('backend') === 'yes'
+      const withBackend = urlSearchParams.get('backend') === 'yes'
       const backendUrl = withBackend && 'http://localhost:3007'
 
       // enable cacheProvider
-      const withCacheProvider = new URLSearchParams(window.location.search).get('cache') === 'yes'
+      const withCacheProvider = urlSearchParams.get('cache') === 'yes'
 
       // hide modals
-      const keepModalHidden = new URLSearchParams(window.location.search).get('keepModalHidden') === 'yes'
+      const keepModalHidden = urlSearchParams.get('keepModalHidden') === 'yes'
 
       // networks
       const rpcUrls = {
@@ -125,7 +127,7 @@
       // supportedChains parameter
       const defaultNetworks = Object.keys(rpcUrls).map(Number)
       defaultNetworks.push(1337)
-      const supportedChainsParam = new URLSearchParams(window.location.search).get('supportedChains')
+      const supportedChainsParam = urlSearchParams.get('supportedChains')
       const supportedChains = !supportedChainsParam ?
         defaultNetworks :
         (supportedChainsParam == 'all'? null : supportedChainsParam.split(',').map(chain => parseInt(chain)))
@@ -183,8 +185,8 @@
         },
         rpcUrls,
         infoOptions,
+        defaultTheme: urlSearchParams.get('defaultTheme') || 'light',
         // customThemes: {light:{modalBackground:'#ff0000'}},
-        // defaultTheme: 'dark',
       })
 
       window.rLogin=rLogin;


### PR DESCRIPTION
<!--
  Welcome to RIF Identity!
  Please follow this guidelines to make your PR
  https://developers.rsk.co/rif/identity/contribute/
-->
Closes #264 

**This one is also chained with the others! I am using a refactor done in tests**

I couldn't reproduce the issue. I have added an integration test following the steps:

```ts
// before each: inject metamask + open popup
it('shows wallet info in light after switching', () => {
    switchTheme()
    cy.contains('MetaMask').click()
    cy.get('.rlogin-button.confirm').click()
    cy.get('#showInfo').click()
    testIsLight()
})
```

To test it I added `defaultTheme: urlSearchParams.get('defaultTheme') || 'light',` to sample app config

Took some time for some additional work:
- added some more tests to themes
- refactored `new MockProvider` as a factory method. It accepts setup overrides + a function that is run on provider before loading it into the screen to be able to add extra things like `.isLedger = true`.
- also updated `mock-web3-provider` to `v1.0.1` that addas `.isMetamask` by default



