### PR TITLE
Hide nifty wallet unless the user has it enabled

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         node-version: 14.x
 
-    - run: npm audit
+    - run: npm audit --production

--- a/cypress/integration/1-modal/rlogin-providers_spec.js
+++ b/cypress/integration/1-modal/rlogin-providers_spec.js
@@ -1,0 +1,23 @@
+import { mockInjectedProvider } from '../account'
+
+describe('rLogin modal loading while user confirms wallet', () => {
+  it('hides Nifty wallet when it is not present', () => {
+    mockInjectedProvider()
+    cy.visit('/')
+    cy.contains('login with rLogin').click()
+
+    cy.contains('Nifty').should('not.exist')
+  })
+
+  it('shows Nifty', () => {
+    mockInjectedProvider({}, (provider) => {
+      provider.isMetaMask = null
+      provider.isNiftyWallet = true
+    })
+
+    cy.visit('/')
+    cy.contains('login with rLogin').click()
+
+    cy.contains('Nifty').should('exist')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0",
   "description": "Login tool for RSK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -82,7 +82,7 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
     <ProvidersWrapper className={PROVIDERS_WRAPPER_CLASSNAME}>
       <ProviderRow className={PROVIDERS_INJECTED}>
         <Provider userProvider={providersByName[providers.METAMASK.name] || providers.METAMASK} handleConnect={handleConnect} hideIfDisabled={false} />
-        <Provider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} hideIfDisabled={false} />
+        <Provider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} hideIfDisabled={true} />
         <Provider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={false} />
         <Provider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
       </ProviderRow>


### PR DESCRIPTION
Title is the primary update, however, what started as a very easy fix revealed a security issue with a dependency used in the testing framework. Fixing this error then illuminated issues in our tests with a missing typescript property as well as a missing polyfills. Fixing these then had issues with the install.

I have changed the npm audit command to only run on production dependencies and reverted the package updates. 


Resolves #278
