### PR TITLE
Get WalletConnect 2.0 to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add wallets peer dependecies:
 | Wallet provider | Required package |
 | - | - |
 | Browser wallets | none |
-| Wallet Connect | `@walletconnect/web3-provider` |
+| Wallet Connect | `@rsksmart/rlogin-walletconnect2-provider` |
 | Portis | `@portis/web3` |
 | Torus (beta) | `@toruslabs/torus-embed` |
 | Trezor | `@rsksmart/rlogin-trezor-provider` |
@@ -76,14 +76,14 @@ Add wallets peer dependecies:
 | D'Cent | `@rsksmart/rlogin-dcent-provider` |
 
 ```
-yarn add @walletconnect/web3-provider @portis/web3 @toruslabs/torus-embed @rsksmart/rlogin-trezor-provider @rsksmart/rlogin-ledger-provider @rsksmart/rlogin-dcent-provider
+yarn add @rsksmart/rlogin-walletconnect2-provider @portis/web3 @toruslabs/torus-embed @rsksmart/rlogin-trezor-provider @rsksmart/rlogin-ledger-provider @rsksmart/rlogin-dcent-provider
 ```
 
 ### 2. Create the DOM element
 
 ```typescript
 import RLogin from '@rsksmart/rlogin'
-import WalletConnectProvider from '@walletconnect/web3-provider'
+import { WalletConnect2Provider } from '@rsksmart/rlogin-walletconnect2-provider'
 import Portis from '@portis/web3'
 import Torus from '@toruslabs/torus-embed'
 import { trezorProviderOptions } from '@rsksmart/rlogin-trezor-provider'
@@ -105,9 +105,12 @@ const infoOptions = {
 export const rLogin = new RLogin({
   providerOptions: {
     walletconnect: {
-      package: WalletConnectProvider,
+      package: WalletConnect2Provider,
       options: {
-        rpc: rpcUrls
+        projectId: 'PROJECTID',
+        chains: ['31'],
+        showQrModal: true,
+        rpcMap: rpcUrls,
       }
     },
     portis: {

--- a/cypress/integration/1-modal/rlogin-modal_spec.js
+++ b/cypress/integration/1-modal/rlogin-modal_spec.js
@@ -20,6 +20,6 @@ describe('rLoign modal interaction', () => {
 
   it('shows a QR code for WalletConnect', () => {
     cy.contains('WalletConnect').click()
-    cy.get('#walletconnect-qrcode-text').should('exist')
+    cy.get('wcm-modal')
   })
 })

--- a/cypress/integration/1-modal/rlogin-retry-provider_spec.js
+++ b/cypress/integration/1-modal/rlogin-retry-provider_spec.js
@@ -25,6 +25,6 @@ describe('modal - chose metamask fails, then walletconnect works', () => {
   it('shows a QR code for WalletConnect', () => { // try with WalletConnect should work
     cy.contains('login with rLogin').click()
     cy.contains('WalletConnect').click()
-    cy.get('#walletconnect-qrcode-text').should('exist')
+    cy.get('wcm-modal')
   })
 })

--- a/cypress/integration/4-mobile/mobile-integration.js
+++ b/cypress/integration/4-mobile/mobile-integration.js
@@ -7,6 +7,6 @@ describe('rLoign modal interaction', () => {
   it('shows a QR code for WalletConnect', () => {
     cy.viewport(480, 750)
     cy.contains('WalletConnect').click()
-    cy.get('#walletconnect-qrcode-text').should('exist')
+    cy.get('wcm-modal')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.5.2",
+  "version": "1.5.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rlogin",
-      "version": "1.5.2",
+      "version": "1.5.3-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.5.2",
+  "version": "1.5.3-beta.1",
   "description": "Login tool for RSK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -50,7 +50,7 @@
 
     <!-- Mobile
     <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js" integrity="sha384-e1LVDbPXlpouaOa/B5TOOA/EeKsLWbCQpRC6XB5RBn0eKI8E1msrTnw8Dvkft020" crossorigin="anonymous"></script> -->
-    <script src="https://unpkg.com/@rsksmart/rlogin-walletconnect2-provider@1.0.0/dist/bundle.js" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@rsksmart/rlogin-walletconnect2-provider@1.0.0/dist/bundle.js" integrity="sha384-b45t2uis3XhbvsJcTjcjp/qYB2AeKvfznFptmQItG3RhSKDyrmHoKJKtrHyXJmHY" crossorigin="anonymous"></script>
 
     <!-- Custodial -->
     <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js" integrity="sha384-rVrQx3OPQbx/BulpfW0MLzID/fIM+x2qiI9Ibhpgd8MKK7wqsVPRRLDMQDWU7zS3" crossorigin="anonymous"></script>

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -48,8 +48,7 @@
 
     <script src="http://localhost:3005/index.js"></script>
 
-    <!-- Mobile
-    <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js" integrity="sha384-e1LVDbPXlpouaOa/B5TOOA/EeKsLWbCQpRC6XB5RBn0eKI8E1msrTnw8Dvkft020" crossorigin="anonymous"></script> -->
+    <!-- Mobile -->
     <script src="https://unpkg.com/@rsksmart/rlogin-walletconnect2-provider@1.0.0/dist/bundle.js" integrity="sha384-b45t2uis3XhbvsJcTjcjp/qYB2AeKvfznFptmQItG3RhSKDyrmHoKJKtrHyXJmHY" crossorigin="anonymous"></script>
 
     <!-- Custodial -->

--- a/sample/front/index.html
+++ b/sample/front/index.html
@@ -48,8 +48,9 @@
 
     <script src="http://localhost:3005/index.js"></script>
 
-    <!-- Mobile -->
-    <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js" integrity="sha384-e1LVDbPXlpouaOa/B5TOOA/EeKsLWbCQpRC6XB5RBn0eKI8E1msrTnw8Dvkft020" crossorigin="anonymous"></script>
+    <!-- Mobile
+    <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.2/dist/umd/index.min.js" integrity="sha384-e1LVDbPXlpouaOa/B5TOOA/EeKsLWbCQpRC6XB5RBn0eKI8E1msrTnw8Dvkft020" crossorigin="anonymous"></script> -->
+    <script src="https://unpkg.com/@rsksmart/rlogin-walletconnect2-provider@1.0.0/dist/bundle.js" crossorigin="anonymous"></script>
 
     <!-- Custodial -->
     <script src="https://unpkg.com/@portis/web3@4.0.0/umd/index.js" integrity="sha384-rVrQx3OPQbx/BulpfW0MLzID/fIM+x2qiI9Ibhpgd8MKK7wqsVPRRLDMQDWU7zS3" crossorigin="anonymous"></script>
@@ -146,10 +147,12 @@
         cacheProvider: withCacheProvider,
         providerOptions: {
           walletconnect: {
-            package: window.WalletConnectProvider.default,
+            package: window.rLoginWalletConnect2Provider.WalletConnect2Provider,
             options: {
-              bridge: "https://walletconnect-bridge.rifos.org/",
-              rpc: rpcUrls
+              projectId: '4d14850f2288242161063a7dd66a7b0a',
+              chains: ['31'],
+              showQrModal: true,
+              rpcMap: rpcUrls,
             }
           },
           portis: {

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -41,6 +41,17 @@ export class RLoginProviderController {
         providerInfo = getProviderInfoById(id)
       }
 
+      if (providerInfo.id === 'walletconnect') {
+        // console.log('TACO!', providerInfo)
+        providerInfo = {
+          ...providerInfo,
+          package: {
+            ...providerInfo.package,
+            required: ['projectId', 'chains']
+          }
+        }
+      }
+
       // parse custom display options
       if (this.providerOptions[id]) {
         const options = this.providerOptions[id]

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -3,6 +3,7 @@ import { EventController, IProviderInfo, IProviderDisplayWithConnector, IProvide
 
 import { RLoginIProviderUserOptions } from '../Core'
 import { RLOGIN_SELECTED_PROVIDER, CACHED_PROVIDER_KEY } from '../constants'
+import { walletConnect2Provider } from './walletconnect2'
 
 export class RLoginProviderController {
   public cachedProvider: string = '';
@@ -41,15 +42,9 @@ export class RLoginProviderController {
         providerInfo = getProviderInfoById(id)
       }
 
+      // Handles WalletConnect 2.0
       if (providerInfo.id === 'walletconnect') {
-        // console.log('TACO!', providerInfo)
-        providerInfo = {
-          ...providerInfo,
-          package: {
-            ...providerInfo.package,
-            required: ['projectId', 'chains']
-          }
-        }
+        return (walletConnect2Provider(providerInfo))
       }
 
       // parse custom display options

--- a/src/controllers/walletconnect2.ts
+++ b/src/controllers/walletconnect2.ts
@@ -1,0 +1,23 @@
+import { IProviderInfo } from 'web3modal'
+
+/**
+ * WalletConnect 2.0 Provider Modifications
+ * To be compatiable with WC2.0  the following change is needed. RLogin is not up to date with web3modal
+ * and as such, this patch is needed until we can update.
+ * @param providerInfo IProviderInfo
+ * @returns provider
+ */
+export const walletConnect2Provider = (providerInfo: IProviderInfo) => {
+  return {
+    ...providerInfo,
+    connector: async (ProviderPackage: any, options: any) => {
+      const provider = new ProviderPackage(options)
+      await provider.connect()
+      return provider
+    },
+    package: {
+      ...providerInfo.package,
+      required: ['projectId', 'chains']
+    }
+  }
+}


### PR DESCRIPTION
Using the new [@rsksmart/rlogin-walletconnect2-provider](https://www.npmjs.com/package/@rsksmart/rlogin-walletconnect2-provider), get WalletConnect 2.0 to work with rLogin.

Creates a temporary patch because rLogin is behind web3modal. When we have additional time we can analysis how to best update the dependencies. For now, this is a workable approach. 