### PR TITLE
Logging the package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.5.3-beta.1",
+  "version": "1.5.3-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rlogin",
-      "version": "1.5.3-beta.1",
+      "version": "1.5.3-beta.2",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.5.3-beta.1",
+  "version": "1.5.3-beta.2",
   "description": "Login tool for RSK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/RLogin.tsx
+++ b/src/RLogin.tsx
@@ -25,6 +25,8 @@ import { InfoOptions } from './ux/confirmInformation/InfoOptions'
 // copy-pasted and adapted
 // https://github.com/Web3Modal/web3modal/blob/4b31a6bdf5a4f81bf20de38c45c67576c3249bfc/src/core/index.tsx
 
+const { version: rLoginVersion } = require('../package.json')
+
 const defaultOpts: IProviderControllerOptions = {
   cacheProvider: false,
   disableInjectedProvider: false,
@@ -101,6 +103,8 @@ export class RLogin {
     this.coreRef = React.createRef()
 
     this.renderModal()
+
+    console.log('rLogin version', rLoginVersion)
   }
 
   get cachedProvider (): string {


### PR DESCRIPTION
Developer/User/Product should be able to verify the version of rLogin a dapp is using based on the package.json version.

<img width="1110" alt="image" src="https://github.com/rsksmart/rLogin/assets/4074139/9ea1390f-1a39-4b10-8c69-f20c7b4b6f16">
