### PR TITLE
Update WalletProviders.tsx to remove liquality as a default provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin",
-  "version": "1.6.0-beta.4",
+  "version": "1.6.1",
   "description": "Login tool for RSK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/ux/step1/WalletProviders.tsx
+++ b/src/ux/step1/WalletProviders.tsx
@@ -82,7 +82,7 @@ export const WalletProviders = ({ userProviders, connectToWallet, changeLanguage
       <ProviderRow className={PROVIDERS_INJECTED}>
         <Provider userProvider={providersByName[providers.METAMASK.name] || providers.METAMASK} handleConnect={handleConnect} hideIfDisabled={false} />
         <Provider userProvider={providersByName[providers.NIFTY.name] || providers.NIFTY} handleConnect={handleConnect} hideIfDisabled={true} />
-        <Provider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={false} />
+        <Provider userProvider={providersByName[providers.LIQUALITY.name] || providers.LIQUALITY} handleConnect={handleConnect} hideIfDisabled={true} />
         <Provider userProvider={providersByName[TALLYWALLET.name] || TALLYWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
         <Provider userProvider={providersByName[BLOCKWALLET.name] || BLOCKWALLET} handleConnect={handleConnect} hideIfDisabled={true} />
         <Provider userProvider={providersByName[ENKRYPTWALLET.name] || ENKRYPTWALLET} handleConnect={handleConnect} hideIfDisabled={true} />


### PR DESCRIPTION
Removes the provider as a default option, if the user has it installed it will still show up and can be used.

Also bumps version to 1.6.0 since we haven't received feedback from partners regarding issues with the recent additions.
